### PR TITLE
Write an answers template on install

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -9,6 +9,7 @@ PARAMS_KEY="params"
 MAIN_FILE="nulecule"
 PARAMS_FILE="params.conf"
 ANSWERS_FILE="answers.conf"
+ANSWERS_FILE_SAMPLE="answers.conf.sample"
 
 DEFAULT_PROVIDER="kubernetes"
-DEFAULT_ANSWERS={"general":{}}
+DEFAULT_ANSWERS={"general":{"provider":DEFAULT_PROVIDER}}

--- a/atomicapp/install.py
+++ b/atomicapp/install.py
@@ -70,9 +70,7 @@ class Install():
         self.utils.checkArtifacts()
     
     def install(self):
-
-        if not self.params.loadAnswers(self.answers_file):
-            logger.info("No %s file found, using defaults" % ANSWERS_FILE)
+        self.params.loadAnswers(self.answers_file)
 
         if self.params.app_path and not self.params.target_path == self.params.app_path:
             logger.info("Copying content of directory %s to %s" % (self.params.app_path, self.params.target_path))
@@ -103,7 +101,9 @@ class Install():
         logger.debug(values)
         self.params.loadAnswers(values)
         logger.debug(self.params.answers_data)
-        self.params.writeAnswersSample()
+        if self.params.write_sample_answers:
+            print("blah")
+            self.params.writeAnswersSample()
 
         return values
 
@@ -123,7 +123,7 @@ class Install():
             logger.debug("Component path: %s" % component_path)
             if not component == self.params.app_id and (not os.path.isdir(component_path) or self.params.update): #not self.params.app_path or  ???
                 logger.info("Pulling %s" % image_name)
-                component_app = Install(self.answers_file, image_name, self.params.nodeps, self.params.update, component_path, self.dryrun)
+                component_app = Install(self.params.answers_data, image_name, self.params.nodeps, self.params.update, component_path, self.dryrun)
                 values = self.params._update(values, component_app.install())
                 logger.info("Component installed into %s" % component_path)
             else:

--- a/atomicapp/params.py
+++ b/atomicapp/params.py
@@ -171,12 +171,13 @@ class Params(object):
             component_config = self._update(component_config, config)
 
         if component in self.answers_data:
-            component_config = self._update(component_config, self.answers_data[component])
+            tmp_clean_answers = self._cleanNullValues(self.answers_data[component])
+            component_config = self._update(component_config, tmp_clean_answers)
         return component_config
 
     def _getValue(self, param, name, skip_asking = False):
         value = None
-        logger.debug("Skip asking: %s" % skip_asking)
+
         if type(param) == dict:
             if "default" in param:
                 value = param["default"]
@@ -221,6 +222,14 @@ class Params(object):
                         repeat = True
 
         return value
+
+    def _cleanNullValues(self, data):
+        result = {}
+        for name, value in data.iteritems():
+            if value:
+                result[name] = value
+
+        return result
 
     def _updateAnswers(self, component, param, value):
         if not component in self.answers_data:

--- a/atomicapp/params.py
+++ b/atomicapp/params.py
@@ -26,6 +26,7 @@ class Params(object):
     __provider = DEFAULT_PROVIDER
     __app = None
     ask = False
+    write_sample_answers = False
 
     @property
     def app(self):
@@ -107,7 +108,6 @@ class Params(object):
         if not data:
             raise Exception("No data answers data given")
 
-        use_default = False
 
         if type(data) == dict:
             logger.debug("Data given %s" % data)
@@ -117,24 +117,20 @@ class Params(object):
                 if os.path.isfile(os.path.join(data, ANSWERS_FILE)):
                     data = os.path.isfile(os.path.join(data, ANSWERS_FILE))
                 else:
-                    use_default = True
+                    self.write_sample_answers = True
 
             if os.path.isfile(data):
                 data = anymarkup.parse_file(data)
         else:
-            use_default = True
+            self.write_sample_answers = True
 
-        if use_default:
-            logger.warning("No answers file found.")
+        if  self.write_sample_answers:
             data = DEFAULT_ANSWERS
 
         if self.answers_data:
             self.answers_data = self._update(self.answers_data, data)
         else:
             self.answers_data = data
-
-        if use_default:
-            self.writeAnswersSample()
 
         return self.answers_data
 

--- a/atomicapp/params.py
+++ b/atomicapp/params.py
@@ -51,6 +51,8 @@ class Params(object):
 
     @target_path.setter
     def target_path(self, path):
+        if not path:
+            path = os.getcwd()
         if not os.path.isdir(path):
             os.makedirs(path)
 

--- a/atomicapp/params.py
+++ b/atomicapp/params.py
@@ -8,7 +8,7 @@ import re
 import pprint
 from collections import OrderedDict
 
-from constants import MAIN_FILE, GLOBAL_CONF, DEFAULT_PROVIDER, PARAMS_KEY, ANSWERS_FILE, DEFAULT_ANSWERS
+from constants import MAIN_FILE, GLOBAL_CONF, DEFAULT_PROVIDER, PARAMS_KEY, ANSWERS_FILE, DEFAULT_ANSWERS, ANSWERS_FILE_SAMPLE
 
 import utils
 
@@ -96,6 +96,8 @@ class Params(object):
         if not data:
             raise Exception("No data answers data given")
 
+        use_default = False
+
         if type(data) == dict:
             logger.debug("Data given %s" % data)
         elif os.path.exists(data):
@@ -104,12 +106,14 @@ class Params(object):
                 if os.path.isfile(os.path.join(data, ANSWERS_FILE)):
                     data = os.path.isfile(os.path.join(data, ANSWERS_FILE))
                 else:
-                    logger.warning("No answers file found.")
-                    data = DEFAULT_ANSWERS
+                    use_default = True
 
             if os.path.isfile(data):
                 data = anymarkup.parse_file(data)
         else:
+            use_default = True
+
+        if use_default:
             logger.warning("No answers file found.")
             data = DEFAULT_ANSWERS
 
@@ -117,6 +121,10 @@ class Params(object):
             self.answers_data = self._update(self.answers_data, data)
         else:
             self.answers_data = data
+
+        if use_default:
+            self.writeAnswers(os.path.join(self.target_path, ANSWERS_FILE_SAMPLE))
+
         return self.answers_data
 
     def get(self, component = None):
@@ -220,7 +228,7 @@ class Params(object):
         self.answers_data[component][param] = value
 
     def writeAnswers(self, path):
-        anymarkup.serialize_file(self.answers_data, path, format='yaml')
+        anymarkup.serialize_file(self.answers_data, path, format='ini')
 
     def _update(self, old_dict, new_dict):
         for key, val in new_dict.iteritems():


### PR DESCRIPTION
As discussed in issue #26, this PR writes the `answers.conf.sample` at the end of the `atomicapp install`. It contains all params for all components pre-filled with the known defaults or `None` if the default is not set.

```
[vpavlin@dhcp-30-155 ~/devel/upstream/atomicapp/test-app(master)]
$ ls
[vpavlin@dhcp-30-155 ~/devel/upstream/atomicapp/test-app(master)]
$ atomicapp install vpavlin/wp-app
2015-05-09 11:01:18,502 - atomicapp.install - INFO - App name is vpavlin/wp-app, will be populated to None
Trying to pull repository docker.io/vpavlin/wp-app ...
eb9beee86635: Download complete 
48ecf305d2cf: Download complete 
93be8052dfb8: Download complete 
d364b63640ba: Download complete 
191c9f2e2f36: Download complete 
d2651828afb8: Download complete 
2899b24724a5: Download complete 
50f29c5875bf: Download complete 
86943f2fd311: Download complete 
f576de234d78: Download complete 
0d01d6974ff9: Download complete 
c48b7d2e2a46: Download complete 
4d573f10028e: Download complete 
ba19aaf75e96: Download complete 
05c735695902: Download complete 
73a89e479333: Download complete 
5a8d0232f27d: Download complete 
Status: Image is up to date for docker.io/vpavlin/wp-app:latest
d7d8e4c2d87e2f16951974ac8805f6e6349bf35cdf6c2745cdc3cb98db72a195
2015-05-09 11:01:26,018 - atomicapp.utils - INFO - Using temporary directory /tmp/appent-wp-appvt01OY
wp-app
2015-05-09 11:01:26,455 - atomicapp.install - INFO - Copying app wp-app
2015-05-09 11:01:26,457 - atomicapp.utils - INFO - Artifacts for wordpress-app present for these providers: docker, openshift
2015-05-09 11:01:26,457 - atomicapp.install - INFO - Installing dependencies for wordpress-app
2015-05-09 11:01:26,457 - atomicapp.install - INFO - Component mariadb-app is external dependency
2015-05-09 11:01:26,458 - atomicapp.install - INFO - Pulling vpavlin/mariadb-app
2015-05-09 11:01:26,459 - atomicapp.install - INFO - App name is vpavlin/mariadb-app, will be populated to /home/vpavlin/devel/upstream/atomicapp/test-app/external/mariadb-app
Trying to pull repository docker.io/vpavlin/mariadb-app ...
d91c51dd843b: Download complete 
48ecf305d2cf: Download complete 
93be8052dfb8: Download complete 
d364b63640ba: Download complete 
191c9f2e2f36: Download complete 
d2651828afb8: Download complete 
2899b24724a5: Download complete 
50f29c5875bf: Download complete 
86943f2fd311: Download complete 
f576de234d78: Download complete 
0d01d6974ff9: Download complete 
c48b7d2e2a46: Download complete 
4d573f10028e: Download complete 
ba19aaf75e96: Download complete 
05c735695902: Download complete 
73a89e479333: Download complete 
5166ceec1dcf: Download complete 
Status: Image is up to date for docker.io/vpavlin/mariadb-app:latest
b2638d9f597d9747615cf71a3f36c69fe00cce2d43e13dffce93ae0a15571570
2015-05-09 11:01:34,051 - atomicapp.utils - INFO - Using temporary directory /tmp/appent-mariadb-app_XTEM9
mariadb-app
2015-05-09 11:01:34,481 - atomicapp.install - INFO - Copying app mariadb-app
2015-05-09 11:01:34,483 - atomicapp.utils - INFO - Artifacts for mariadb-app present for these providers: docker, openshift
2015-05-09 11:01:34,483 - atomicapp.install - INFO - Installing dependencies for mariadb-app
2015-05-09 11:01:34,484 - atomicapp.install - INFO - Component installed into /home/vpavlin/devel/upstream/atomicapp/test-app/external/mariadb-app
blah
2015-05-09 11:01:34,484 - atomicapp.params - INFO - Writing answers file template to /home/vpavlin/devel/upstream/atomicapp/test-app/answers.conf.sample
[vpavlin@dhcp-30-155 ~/devel/upstream/atomicapp/test-app(master)]
$ ls
answers.conf.sample  Dockerfile  external  graph  nulecule  README.md
[vpavlin@dhcp-30-155 ~/devel/upstream/atomicapp/test-app(master)]
$ more answers.conf.sample 
[mariadb-app]
image = vpavlin/mariadb
name = mariadb
[wordpress-app]
image = vpavlin/wordpress
name = wordpress
[general]
provider = kubernetes
```