### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,5 @@ VOLUME /application-entity
 LABEL RUN docker run -it --rm --privileged --net=host -v ${PWD}:/atomicapp -v /run:/run  --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v run /atomicapp
 LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE -v install --path /atomicapp /application-entity
 
-ENTRYPOINT atomicapp -h
+ENTRYPOINT ["/usr/bin/atomicapp"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ WORKDIR /opt/atomicapp
 RUN python setup.py install
 
 WORKDIR /application-entity
-VOLUME /application-entity/answers.conf
+VOLUME /application-entity
 
-LABEL RUN docker run -it --rm --privileged --net=host -v ${PWD}:/atomicapp -v /run:/run -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE atomicapp -v run /atomicapp
-LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE atomicapp -v install --path /atomicapp /application-entity
+LABEL RUN docker run -it --rm --privileged --net=host -v ${PWD}:/atomicapp -v /run:/run  --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v run /atomicapp
+LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE -v install --path /atomicapp /application-entity
 
-CMD atomicapp -h
+ENTRYPOINT atomicapp -h
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ WORKDIR /opt/atomicapp
 
 RUN python setup.py install
 
-WORKDIR /application-entity
-VOLUME /application-entity
+WORKDIR /atomicapp
+VOLUME /atomicapp
 
-LABEL RUN docker run -it --rm --privileged --net=host -v ${PWD}:/atomicapp -v /run:/run  --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v run /atomicapp
-LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE -v install --path /atomicapp /application-entity
+LABEL RUN docker run -it --rm --privileged --net=host -v ${PWD}:/atomicapp -v /run:/run -v /:/host --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v run /atomicapp
+LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE -v install --destination /atomicapp /application-entity
 
 ENTRYPOINT ["/usr/bin/atomicapp"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:centos7
 
 MAINTAINER Vaclav Pavlin <vpavlin@redhat.com>
 

--- a/atomicapp.sh
+++ b/atomicapp.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+if [ "$1" == "-h" -o "$1" == "--help" ]; then
+    echo "This script let's you to run the atomicapp container as a tool."
+    echo "All arguments are passed to docker run command for image projectatomic/atomicapp"
+    echo "Current directory (`pwd`) is mounted to the container as /atomicapp"
+fi
+
+docker run -it --rm --net=host --privileged -v /run:/run -v /:/host -v `pwd`:/atomicapp projectatomic/atomicapp $@


### PR DESCRIPTION
This  changes adds `atomicapp.sh` script to simply make the container behave as an executable (tested with `install`, `run` and `build`...`create` is broken right now)

```
bash-4.2# rm -rf *
bash-4.2# ls
bash-4.2# ../atomicapp.sh install vpavlin/wp-app
2015-05-09 15:53:57,149 - atomicapp.install - INFO - App name is vpavlin/wp-app, will be populated to None
b05199a619b2c9399e1623276ede2a4de924244fb7dee1a1864e2a5e7f4d942c
2015-05-09 15:53:58,146 - atomicapp.utils - INFO - Using temporary directory /tmp/appent-wp-appW0XU5C
wp-app
2015-05-09 15:53:58,559 - atomicapp.install - INFO - Copying app wp-app
2015-05-09 15:53:58,563 - atomicapp.utils - INFO - Artifacts for wordpress-app present for these providers: docker, openshift
2015-05-09 15:53:58,563 - atomicapp.install - INFO - Installing dependencies for wordpress-app
2015-05-09 15:53:58,563 - atomicapp.install - INFO - Component mariadb-app is external dependency
2015-05-09 15:53:58,564 - atomicapp.install - INFO - Pulling vpavlin/mariadb-app
2015-05-09 15:53:58,564 - atomicapp.install - INFO - App name is vpavlin/mariadb-app, will be populated to /atomicapp/external/mariadb-app
1a06547b73a5b4eb15916895800be39e49eaba03f9d3357e03b83f790bc7f938
2015-05-09 15:53:59,456 - atomicapp.utils - INFO - Using temporary directory /tmp/appent-mariadb-appQKhIr0
mariadb-app
2015-05-09 15:53:59,977 - atomicapp.install - INFO - Copying app mariadb-app
2015-05-09 15:53:59,980 - atomicapp.utils - INFO - Artifacts for mariadb-app present for these providers: docker, openshift
2015-05-09 15:53:59,980 - atomicapp.install - INFO - Installing dependencies for mariadb-app
2015-05-09 15:53:59,981 - atomicapp.install - INFO - Component installed into /atomicapp/external/mariadb-app
blah
2015-05-09 15:53:59,981 - atomicapp.params - INFO - Writing answers file template to /atomicapp/answers.conf.sample
bash-4.2# ls
answers.conf.sample  Dockerfile  external  graph  nulecule  README.md
```

Probably needs some how to docs...

Dockerfile changes:
`WORKDIR` changed to `/atomicapp` as that's where all writes changes
Removed mount of `answers.conf` - we expect them in `pwd` anyway..
Fixed `--path` to `--destination` change
And changed `CMD` to `ENTRYPOINT` to support @whitel's use case 