### PR TITLE
fix dependencies in centos and fedora images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Vaclav Pavlin <vpavlin@redhat.com>
 
 RUN echo -e "[epel]\nname=epel\nenabled=1\nbaseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/\ngpgcheck=0" > /etc/yum.repos.d/epel.repo
 
-RUN yum install -y --setopt=tsflags=nodocs python-pip docker && \
+RUN yum install -y --setopt=tsflags=nodocs python-pip python-devel docker gcc libyaml-devel && \
     yum clean all
 
 ADD atomicapp/ /opt/atomicapp/atomicapp/

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -2,7 +2,7 @@ FROM fedora
 MAINTAINER langdon <langdon@fedoraproject.org>
 #Derived from Vaclav Pavlin <vpavlin@redhat.com>; https://github.com/vpavlin/atomicapp-run
 
-RUN yum -y install python python-pip docker && \
+RUN yum install -y python-pip docker python-devel gcc libyaml-devel && \
     yum update -y && \
     yum clean all
 


### PR DESCRIPTION
Without these dependencies, PyYAML cannot be installed.