### PR TITLE
Fix arguments and their description in README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -33,7 +33,7 @@ Calls Docker build to package up the application and tags the resulting image.
 
 === Install and Run
 ```
-atomicapp [--dry-run] [-a answers.conf] install|run [--recursive] [--update] [--path PATH] APP|PATH 
+atomicapp [--dry-run] [-a answers.conf] install|run [--recursive] [--update] [--destination DST_PATH] APP|PATH
 ```
 
 Pulls the application and it's dependencies. If the last argument is
@@ -41,13 +41,15 @@ existing path, it looks for `Nulecule` file there instead of pulling anything.
 
 * `--recursive yes|no` Pull whole dependency tree
 * `--update` Overwrite any existing files
-* `--path PATH` Unpack the application into given directory instead of current directory
+* `--destination DST_PATH` Unpack the application into given directory instead of current directory
+* `APP` Name of the image containing the application (f.e. `vpavlin/wp-app`)
+* `PATH` Path to a directory with installed (i.e. result of `atomicapp install ...`) app
 
-Action `run` performs `install` prior it's own tasks are executed. When `run` is selected, providers' code is invoked and containers are deployed.
+Action `run` performs `install` prior it's own tasks are executed if `APP` is given. When `run` is selected, providers' code is invoked and containers are deployed.
 
 == Providers
 
-Providers represent various deployment targets. They are based on yapsy plugin system and can be added by implementing interface explained in [Providers](providers/README.md)
+Providers represent various deployment targets. They can be added by placing a `provider_name.py` file implementing interface explained in providers/README.md[Providers] into `providers/` directory.
 
 == Dependencies
 


### PR DESCRIPTION
We changed argument from `--path` to `--destination` earlier and README didn't reflect that.

I also added a bit of description for `APP` and `PATH`