### PR TITLE
Fix non-working --ask if an image is given to run, generate random name for container

### DIFF
--- a/atomicapp/install.py
+++ b/atomicapp/install.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 import os,sys
 import distutils.dir_util
+import random, string
 
 import subprocess
 
@@ -47,7 +48,8 @@ class Install():
 
     def _copyFromContainer(self, image):
         image = self.utils.getImageURI(image)
-        name = self.utils.getComponentName(image)
+        name = "%s-%s" % (self.utils.getComponentName(image), ''.join(random.sample(string.letters, 6)))
+        logger.debug("Creating a container with name %s" % name)
         
         create = ["docker", "create", "--name", name, image, "nop"]
         subprocess.call(create)

--- a/atomicapp/params.py
+++ b/atomicapp/params.py
@@ -7,6 +7,7 @@ import collections
 import re
 import pprint
 from collections import OrderedDict
+import copy
 
 from constants import MAIN_FILE, GLOBAL_CONF, DEFAULT_PROVIDER, PARAMS_KEY, ANSWERS_FILE, DEFAULT_ANSWERS, ANSWERS_FILE_SAMPLE
 
@@ -127,7 +128,7 @@ class Params(object):
             self.write_sample_answers = True
 
         if  self.write_sample_answers:
-            data = DEFAULT_ANSWERS
+            data = copy.deepcopy(DEFAULT_ANSWERS)
 
         if self.answers_data:
             self.answers_data = self._update(self.answers_data, data)

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -146,7 +146,6 @@ class Run():
 
         self._dispatchGraph()
 
-
 #Think about this a bit more probably - it's (re)written for all components...
         if self.answers_output:
             self.params.writeAnswers(self.answers_output)


### PR DESCRIPTION
Argument `--ask` should force asking for params even if default is specified, with the `install` running as a part of `run`, default answers got filled in by creating an `answers.conf.sample` which then overwritten the the params. The solution is to do a deepcopy of the `DEFAULT_ANSWERS` instead of just assigning it.

Second part is that `install` creates a container with the name of the app. When `atomic` is used, it also creates a container with the name of the image, which means that if the name of the app is the same as the name of the image these 2 containers conflict. This is solved by appending random string to the name of the container created by `install`