### PR TITLE
proper dynamic import of plugins

### DIFF
--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -56,7 +56,7 @@ class Plugin():
             if f.endswith(".py"):
                 module_name = os.path.basename(f).rsplit('.', 1)[0]
                 try:
-                    f_module = imp.load_source("atomicapp.providers.%s" % module_name, os.path.join(providers_dir, f))
+                    f_module = imp.load_source(module_name, os.path.join(providers_dir, f))
                 except (IOError, OSError, ImportError) as ex:
                     logger.warning("can't load module '%s': %s", f, repr(ex))
                     continue


### PR DESCRIPTION
This should fix warnings like:

```
RuntimeWarning: Parent module 'atomicapp.providers' not found while handling absolute import...
```

The problem is the module name passed to `load_source`. We don't need to
put absolute path there, because we are loading the plugin directly from
sources. And that's where the warning comes from: it can't find
'atomicapp.providers' on sys.path so hence the warning.