### PR TITLE
Fix logging in providers

### DIFF
--- a/atomicapp/__init__.py
+++ b/atomicapp/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 def set_logging(name="atomicapp", level=logging.DEBUG):
     # create logger
-    logger = logging.getLogger(name)
+    logger = logging.getLogger()
     logger.handlers = []
     logger.setLevel(level)
 


### PR DESCRIPTION
Logging in providers is currently not printed. This commit fixes it

```
2015-05-14 15:44:41,724 - atomicapp.params - DEBUG - Param provider already in general with value kubernetes
2015-05-14 15:44:41,724 - atomicapp.run - INFO - Using provider kubernetes for component mariadb-app
2015-05-14 15:44:41,724 - kubernetes - DEBUG - /tmp/appent-mariadb-app_Ku6AS/mariadb-app/graph/k8s/mariadb-pod.json
2015-05-14 15:44:41,725 - kubernetes - DEBUG - /tmp/appent-mariadb-app_Ku6AS/mariadb-app/graph/k8s/mariadb-service.json
2015-05-14 15:44:41,726 - kubernetes - INFO - Calling: kubectl create -f /tmp/appent-mariadb-app_Ku6AS/mariadb-app/graph/k8s/mariadb-service.json
2015-05-14 15:44:41,726 - kubernetes - INFO - Calling: kubectl create -f /tmp/appent-mariadb-app_Ku6AS/mariadb-app/graph/k8s/mariadb-pod.json

```