### PR TITLE
Add action 'stop' to atomicapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /atomicapp
 VOLUME /atomicapp
 
 LABEL RUN docker run -it --rm --privileged --net=host -v `pwd`:/atomicapp -v /run:/run -v /:/host --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v run /atomicapp
+LABEL STOP docker run -it --rm --privileged --net=host -v `pwd`:/atomicapp -v /run:/run -v /:/host --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v stop /atomicapp
 LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v `pwd`:/atomicapp -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE -v install --destination /atomicapp /application-entity
 
 ENTRYPOINT ["/usr/bin/atomicapp"]

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -31,6 +31,10 @@ def cli_run(args):
     ae = Run(**vars(args))
     ae.run()
 
+def cli_stop(args):
+    stop = Run(stop = True, **vars(args))
+    stop.run()
+
 class CLI():
     def __init__(self):
         self.parser = ArgumentParser(prog='atomicapp', description='This will install and run an atomicapp, a containerized application conforming to the Nulecule Specification', formatter_class=RawDescriptionHelpFormatter)
@@ -42,6 +46,7 @@ class CLI():
         self.parser.add_argument("-q", "--quiet", dest="quiet", default=False, action="store_true", help="Quiet output mode.")
 
         self.parser.add_argument("--dry-run", dest="dryrun", default=False, action="store_true", help="Don't actually call provider. The commands that should be run will be sent to stdout but not run.")
+        self.parser.add_argument("-a", "--answers", dest="answers", default=os.path.join(os.getcwd(), ANSWERS_FILE), help="Path to %s" % ANSWERS_FILE)
 
         subparsers = self.parser.add_subparsers(dest="action")
 
@@ -52,7 +57,6 @@ class CLI():
 
 
         parser_run = subparsers.add_parser("run")
-        self.parser.add_argument("-a", "--answers", dest="answers", default=os.path.join(os.getcwd(), ANSWERS_FILE), help="Path to %s" % ANSWERS_FILE)
         parser_run.add_argument("--write-answers", dest="answers_output", help="A file which will contain anwsers provided in interactive mode")
         parser_run.add_argument("--ask", default=False, action="store_true", help="Ask for params even if the defaul value is provided")
         parser_run.add_argument("APP", help="Path to the directory where the image is installed.")
@@ -65,6 +69,10 @@ class CLI():
         parser_install.add_argument("--destination", dest="target_path", default=None, help="Destination directory for install")
         parser_install.add_argument("APP",  help="Application to run. This is a container image or a path that contains the metadata describing the whole application.")
         parser_install.set_defaults(func=cli_install)
+
+        parser_stop = subparsers.add_parser("stop")
+        parser_stop.add_argument("APP", help="Path to the directory where the atomicapp is installed or an image containing atomicapp which should be stopped.")
+        parser_stop.set_defaults(func=cli_stop)
 
         parser_build = subparsers.add_parser("build")
         parser_build.add_argument("TAG", nargs="?", default=None, help="Name of the image containing your app")

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -32,6 +32,9 @@ class Provider():
     def deploy(self):
         raise NotImplemented()
 
+    def undeploy(self):
+        logger.warning("Call to undeploy for provider %s failed - this action is not implemented" % self.key)
+
     def __str__(self):
         return "%s" % self.key
 

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 class KubernetesProvider(Provider):
     key = "kubernetes"
 
+    kube_order = OrderedDict([("service", None), ("rc", None), ("pod", None)]) #FIXME
     kubectl = "kubectl"
     def init(self):
         if not self.dryrun and self.container:
@@ -24,21 +25,48 @@ class KubernetesProvider(Provider):
         if not self.dryrun:
             subprocess.check_call(cmd) == 0
 
-    def deploy(self):
-        kube_order = OrderedDict([("service", None), ("rc", None), ("pod", None)]) #FIXME
+    def prepareOrder(self):
         for artifact in self.artifacts:
             data = None
             with open(os.path.join(self.path, artifact), "r") as fp:
                 logger.debug(os.path.join(self.path, artifact))
                 data = anymarkup.parse(fp)
             if "kind" in data:
-                kube_order[data["kind"].lower()] = artifact
+                self.kube_order[data["kind"].lower()] = artifact
             else:
-                logger.info("Malformed kube file")
+                logger.info("Malformed kube file %s" % artifact)
 
-        for artifact in kube_order:
-            if not kube_order[artifact]:
+    def deploy(self):
+        self.prepareOrder()
+
+        for artifact in self.kube_order:
+            if not self.kube_order[artifact]:
                 continue
 
-            k8s_file = os.path.join(self.path, kube_order[artifact])
+            k8s_file = os.path.join(self.path, self.kube_order[artifact])
             self._callK8s(k8s_file)
+
+    def _resetReplicas(self, path):
+        data = anymarkup.parse_file(path)
+        name = data["metadata"]["name"]
+        cmd = [self.kubectl, "resize", "rc", name, "--replicas=4" ]
+        logger.info("Calling: %s" % " ".join(cmd))
+            if not self.dryrun:
+                subprocess.check_call(cmd)
+
+    def undeploy(self):
+        self.prepareOrder()
+
+        for kind, artifact in self.kube_order.iteritems():
+            if not self.kube_order[kind]:
+                continue
+
+            path = os.path.join(self.path, artifact)
+
+            if kind in ["ReplicationController", "rc", "replicationcontroller"]:
+                self._resetReplicas(path)
+
+            cmd = [self.kubectl, "delete", "-f", path]
+            logger.info("Calling: %s" % " ".join(cmd))
+            if not self.dryrun:
+                subprocess.check_call(cmd)

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -33,10 +33,11 @@ class Run():
     answers_output = None
     kwargs = None
 
-    def __init__(self, answers, APP, dryrun = False, debug = False, **kwargs):
+    def __init__(self, answers, APP, dryrun = False, debug = False, stop = False, **kwargs):
 
         self.debug = debug
         self.dryrun = dryrun
+        self.stop = stop
         self.kwargs = kwargs
         if "answers_output" in kwargs:
             self.answers_output = kwargs["answers_output"]
@@ -142,7 +143,10 @@ class Run():
         else:
             raise Exception("Something is broken - couldn't get the provider")
         provider.init()
-        provider.deploy()
+        if self.stop:
+            provider.undeploy()
+        else:
+            provider.deploy()
 
     def run(self):
         self.params.loadMainfile(os.path.join(self.params.target_path, MAIN_FILE))


### PR DESCRIPTION
This adds an 'undeploy' method to Provider interface and an
implementation to kubes provider which removes all services/rc/pods
deployed by 'atomicapp run'

It's currently blocked by https://github.com/projectatomic/atomic/pull/54 to be used as

```
atomic stop my/awesome-atomicapp
```