### PR TITLE
Add property workdir to utils

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -13,6 +13,7 @@ MAIN_FILE="nulecule"
 PARAMS_FILE="params.conf"
 ANSWERS_FILE="answers.conf"
 ANSWERS_FILE_SAMPLE="answers.conf.sample"
+WORKDIR=".workdir"
 
 DEFAULT_PROVIDER="kubernetes"
 DEFAULT_ANSWERS={"general":{"provider":DEFAULT_PROVIDER}}

--- a/atomicapp/install.py
+++ b/atomicapp/install.py
@@ -81,7 +81,7 @@ class Install():
 
         mainfile_path = os.path.join(self.params.target_path, MAIN_FILE)
 
-        if not self.params.app_path and (self.params.update or not os.path.exists(self.utils.getComponentDir(self.params.app))):
+        if not self.params.app_path and (self.params.update or not os.path.exists(mainfile_path)):
             self.utils.pullApp(self.params.app)
             self._copyFromContainer(self.params.app)
             mainfile_path = os.path.join(self.utils.getTmpAppDir(), MAIN_FILE)
@@ -123,8 +123,9 @@ class Install():
 
             image_name = self.utils.getSourceImage(graph_item)
             component_path = self.utils.getExternalAppDir(component)
+            mainfile_component_path = os.path.join(component_path, MAIN_FILE)
             logger.debug("Component path: %s" % component_path)
-            if not component == self.params.app_id and (not os.path.isdir(component_path) or self.params.update): #not self.params.app_path or  ???
+            if not os.path.isfile(mainfile_component_path) or self.params.update:
                 logger.info("Pulling %s" % image_name)
                 component_app = Install(self.params.answers_data, image_name, self.params.nodeps, self.params.update, component_path, self.dryrun)
                 values = self.params._update(values, component_app.install())

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -57,7 +57,14 @@ class Run():
         if "ask" in kwargs:
             self.params.ask = kwargs["ask"]
 
-        self.utils = Utils(self.params)
+        workdir = None
+        if "workdir" in kwargs:
+            workdir = kwargs["workdir"]
+
+        self.utils = Utils(self.params, workdir)
+        if not "workdir" in kwargs:
+            kwargs["workdir"] = self.utils.workdir
+
 
         self.answers_file = answers
         self.plugin = Plugin()
@@ -102,7 +109,7 @@ class Run():
         if not provider in artifacts:
             raise Exception("Data for provider \"%s\" are not part of this app" % self.params.provider)
 
-        dst_dir = os.path.join(self.utils.tmpdir, component)
+        dst_dir = os.path.join(self.utils.workdir, component)
         data = None
 
         for artifact in artifacts[provider]:

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -7,7 +7,7 @@ import tempfile
 
 import logging
 
-from constants import PARAMS_FILE, GRAPH_DIR, GLOBAL_CONF, APP_ENT_PATH, MAIN_FILE, EXTERNAL_APP_DIR
+from constants import PARAMS_FILE, GRAPH_DIR, GLOBAL_CONF, APP_ENT_PATH, MAIN_FILE, EXTERNAL_APP_DIR, WORKDIR
 
 __all__ = ('isTrue', 'Utils')
 
@@ -24,6 +24,17 @@ def isTrue(val):
 class Utils(object):
 
     __tmpdir = None
+    __workdir = None
+
+    @property
+    def workdir(self):
+        if not self.__workdir:
+            self.__workdir = os.path.join(self.params.target_path, WORKDIR)
+            logger.debug(self.__workdir)
+            if not os.path.isdir(self.__workdir):
+                os.mkdir(self.__workdir)
+
+        return self.__workdir
 
     @property
     def tmpdir(self):
@@ -33,8 +44,10 @@ class Utils(object):
 
         return self.__tmpdir
 
-    def __init__(self, params):
+    def __init__(self, params, workdir = None):
         self.params = params
+        if workdir:
+            self.__workdir = workdir
 
     def loadApp(self, app_path):
         self.params.app_path = app_path


### PR DESCRIPTION
Utils now has property workdir which creates and then contains path to a
.workdir directory in a directory containing installed app.

Templated artifacts are then stored in this directory instead of writing
them to /tmp