### PR TITLE
Fail gracefully if kubectl is not available

### DIFF
--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -38,6 +38,9 @@ class Provider():
     def __repr__(self):
         return "Plugin(key='%s')" % self.key
 
+class ProviderFailedException(Exception):
+    """Error during provider execution"""
+
 
 class Plugin():
     plugins = []

--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -1,4 +1,4 @@
-from atomicapp.plugin import Provider
+from atomicapp.plugin import Provider, ProviderFailedException
 import os, subprocess
 
 import logging
@@ -11,7 +11,10 @@ class DockerProvider(Provider):
     def init(self):
 
         cmd_check = ["docker", "version"]
-        docker_version = subprocess.check_output(cmd_check).split("\n")
+        try:
+            docker_version = subprocess.check_output(cmd_check).split("\n")
+        except Exception as ex:
+            raise ProviderFailedException(ex)
 
         client = ""
         server = ""
@@ -22,7 +25,7 @@ class DockerProvider(Provider):
                 server = line.split(":")[1]
 
         if client > server:
-            raise Exception("Docker version in app image (%s) is higher than the one on host (%s). Please update your host." % (client, server))
+            raise ProviderFailedException("Docker version in app image (%s) is higher than the one on host (%s). Please update your host." % (client, server))
 
     def deploy(self):
         for artifact in self.artifacts:

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -9,7 +9,7 @@ import logging
 from params import Params
 from utils import Utils
 from constants import GLOBAL_CONF, DEFAULT_PROVIDER, MAIN_FILE, PARAMS_FILE
-from plugin import Plugin
+from plugin import Plugin, ProviderFailedException
 from install import Install
 
 logger = logging.getLogger(__name__)
@@ -141,8 +141,13 @@ class Run():
             logger.info("Using provider %s for component %s" % (self.params.provider, component))
         else:
             raise Exception("Something is broken - couldn't get the provider")
-        provider.init()
-        provider.deploy()
+
+        try:
+            provider.init()
+            provider.deploy()
+        except ProviderFailedException as ex:
+            logger.error(ex)
+            sys.exit(1)
 
     def run(self):
         self.params.loadMainfile(os.path.join(self.params.target_path, MAIN_FILE))


### PR DESCRIPTION
This fixes #83 

```
$ atomicapp run .
2015-05-18 16:04:07,921 - atomicapp.utils - INFO - Artifacts for drupal present for these providers: docker-compose, kubernetes
2015-05-18 16:04:07,922 - atomicapp.utils - INFO - Artifacts for mariadb-atomicapp present for these providers: 
2015-05-18 16:04:07,924 - atomicapp.utils - INFO - Using temporary directory /tmp/appent-drupal-atomicappoglkss
2015-05-18 16:04:07,926 - atomicapp.run - INFO - Using provider kubernetes for component drupal
2015-05-18 16:04:07,926 - atomicapp.run - ERROR - Command kubectl not found
```