### PR TITLE
Implement simple working openshift provider

### DIFF
--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -15,12 +15,19 @@ class Provider(object):
 
     config = None
     path = None
-    artifacts = None
     dryrun = None
     container = False
-    def __init__(self, config, artifacts, path, dryrun):
-        self.confif = config
-        self.artifacts = artifacts
+    __artifacts = None
+
+    @property
+    def artifacts(self):
+        return self.__artifacts
+    @artifacts.setter
+    def artifacts(self, artifacts):
+        self.__artifacts = artifacts
+
+    def __init__(self, config, path, dryrun):
+        self.config = config
         self.path = path
         self.dryrun = dryrun
         if os.path.exists("/host"):
@@ -34,6 +41,19 @@ class Provider(object):
 
     def undeploy(self):
         logger.warning("Call to undeploy for provider %s failed - this action is not implemented" % self.key)
+    
+    def loadArtifact(self, path):
+        with open(path, "r") as fp:
+            data = fp.read()
+
+        return data
+
+    def saveArtifact(self, path, data):
+        if not os.path.isdir(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+        with open(path, "w") as fp:
+            logger.debug("Writing artifact to %s" % path)
+            fp.write(data)
 
     def __str__(self):
         return "%s" % self.key
@@ -85,7 +105,6 @@ class Plugin(object):
 
     def getProvider(self, provider_key):
         for key, provider in self.plugins.iteritems():
-            logger.debug(key)
             if key == provider_key:
                 logger.debug("Found provider %s", provider)
                 return provider

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -33,10 +33,11 @@ class OpenShiftProvider(Provider):
 
     def _callCli(self, path):
         cmd = [self.cli, "--config=%s" % self.config_file, "create", "-f", path]
-        logger.info("Calling: %s" % " ".join(cmd))
 
         if not self.dryrun:
-            subprocess.check_call(cmd) == 0
+            logger.info("Calling: %s", " ".join(cmd))
+        else:
+            subprocess.check_call(cmd)
 
     def _processTemplate(self, path):
         cmd = [self.cli, "--config=%s" % self.config_file, "process", "-f", path]
@@ -45,8 +46,7 @@ class OpenShiftProvider(Provider):
         output_path = os.path.join(self.path, name)
         if not self.dryrun:
             output = subprocess.check_output(cmd)
-            print(output)
-            logger.debug("Writing processed template to %s" % output_path)
+            logger.debug("Writing processed template to %s", output_path)
             with open(output_path, "w") as fp:
                 fp.write(output)
         return output_path

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -78,8 +78,8 @@ class OpenShiftProvider(Provider):
             with open(artifact_path, "r") as fp:
                 data = anymarkup.parse(fp, force_types=None)
             if "kind" in data:
-#                if data["kind"].lower() == "template":
-#                    artifact = self._processTemplate(artifact_path)
+                if data["kind"].lower() == "template":
+                    artifact = self._processTemplate(artifact_path)
                 kube_order[data["kind"].lower()] = artifact
             else:
                 raise ProviderFailedException("Malformed artifact file")

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -1,33 +1,92 @@
-from atomicapp.plugin import Provider
+from atomicapp.plugin import Provider, ProviderFailedException
 
+<<<<<<< HEAD
 import os, subprocess
+=======
+from collections import OrderedDict
+import os, anymarkup, subprocess
+from distutils.spawn import find_executable
+
+>>>>>>> Implement simple working openshift provider
 import logging
 
 logger = logging.getLogger(__name__)
 
-class OpenshiftProvider(Provider):
+class OpenShiftProvider(Provider):
     key = "openshift"
 
-    config = None
-    path = None
-    artifacts = None
-    dryrun = None
+    cli = find_executable("osc")
+    config_file = None
+    template_data = None
+    def init(self):
+        if not self.dryrun:
+            if self.container:
+                self.cli = "/host/%s" % self.cli
+            if not os.access(self.cli, os.X_OK):
+                raise ProviderFailedException("Command %s not found" % self.cli)
 
-    def _callK8s(self, path):
-        cmd = ["kubectl", "create", "-f", path, "--api-version=v1beta1"]
+        if "openshiftconfig" in self.config:
+            self.config_file = self.config["openshiftconfig"]
 
-        if self.dryrun:
-            logger.info("DRY-RUN: %s", " ".join(cmd))
-            return True
-        else:
-            if subprocess.call(cmd) == 0:
-                return True
+        if not self.config_file or not os.access(self.config_file, os.R_OK):
+            raise ProviderFailedException("Cannot access configuration file %s" % self.config_file)
 
-        return False
+    def _callCli(self, path):
+        cmd = [self.cli, "--config=%s" % self.config_file, "create", "-f", path]
+        logger.info("Calling: %s" % " ".join(cmd))
+
+        if not self.dryrun:
+            subprocess.check_call(cmd) == 0
+
+    def _processTemplate(self, path):
+        cmd = [self.cli, "--config=%s" % self.config_file, "process", "-f", path]
+
+        name = "config-%s" % os.path.basename(path)
+        output_path = os.path.join(self.path, name)
+        if not self.dryrun:
+            output = subprocess.check_output(cmd)
+            print(output)
+            logger.debug("Writing processed template to %s" % output_path)
+            with open(output_path, "w") as fp:
+                fp.write(output)
+        return output_path
+
+    def loadArtifact(self, path):
+        data = super(self.__class__, self).loadArtifact(path)
+        self.template_data = anymarkup.parse(data, force_types=None)
+        if "kind" in self.template_data and self.template_data["kind"].lower() == "template":
+            if "parameters" in self.template_data:
+                return anymarkup.serialize(self.template_data["parameters"], format="json")
+
+        return data
+
+    def saveArtifact(self, path, data):
+        if self.template_data:
+            if "kind" in self.template_data and self.template_data["kind"].lower() == "template":
+                if "parameters" in self.template_data:
+                    passed_data = anymarkup.parse(data, force_types=None)
+                    self.template_data["parameters"] = passed_data
+                    data = anymarkup.serialize(self.template_data, format=os.path.splitext(path)[1].strip(".")) #FIXME
+
+        super(self.__class__, self).saveArtifact(path, data)
 
     def deploy(self):
+        kube_order = OrderedDict([("service", None), ("rc", None), ("pod", None)]) #FIXME
         for artifact in self.artifacts:
+            data = None
             artifact_path = os.path.join(self.path, artifact)
-            logger.debug("Do something about %s", artifact_path)
+            with open(artifact_path, "r") as fp:
+                data = anymarkup.parse(fp, force_types=None)
+            if "kind" in data:
+#                if data["kind"].lower() == "template":
+#                    artifact = self._processTemplate(artifact_path)
+                kube_order[data["kind"].lower()] = artifact
+            else:
+                raise ProviderFailedException("Malformed artifact file")
 
-        logger.info("Files %s merged into imaginary template file and pushed to Openshift...", ", ".join(self.artifacts))
+        for artifact in kube_order:
+            if not kube_order[artifact]:
+                continue
+
+            k8s_file = os.path.join(self.path, kube_order[artifact])
+            self._callCli(k8s_file)

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -153,7 +153,7 @@ class Run(object):
         logger.debug("Processing component %s", component)
 
         provider_class = self.plugin.getProvider(self.params.provider)
-        dst_dir = os.path.join(self.utils.tmpdir, component) #FIXME this should be .workdir
+        dst_dir = os.path.join(self.utils.workdir, component) 
         provider = provider_class(self.params.getValues(component), dst_dir, self.dryrun)
         if provider:
             logger.info("Using provider %s for component %s", self.params.provider, component)

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 import os,sys
 from string import Template
+import copy
 
 import logging
 
@@ -39,6 +40,7 @@ class Run(object):
         self.dryrun = dryrun
         self.stop = stop
         self.kwargs = kwargs
+        
         if "answers_output" in kwargs:
             self.answers_output = kwargs["answers_output"]
 
@@ -46,11 +48,20 @@ class Run(object):
             self.app_path = APP
             APP = os.environ["IMAGE"]
             del os.environ["IMAGE"]
+        elif "image" in kwargs:
+            logger.warning("Setting image to %s" % kwargs["image"])
+
+            self.app_path = APP
+            APP = kwargs["image"]
+            del kwargs["image"]
+
+        self.kwargs = kwargs
 
         if APP and os.path.exists(APP):
             self.app_path = APP
         else:
-            self.app_path = os.getcwd()
+            if not self.app_path:
+                self.app_path = os.getcwd()
             install = Install(answers, APP, dryrun = dryrun, target_path = self.app_path)
             install.install()
 
@@ -77,6 +88,7 @@ class Run(object):
 
         for component, graph_item in self.params.mainfile_data["graph"].iteritems():
             if self.utils.isExternal(graph_item):
+                self.kwargs["image"] = self.utils.getSourceImage(graph_item)
                 component_run = Run(self.answers_file, self.utils.getExternalAppDir(component), self.dryrun, self.debug, **self.kwargs)
                 ret = component_run.run()
                 if self.answers_output:
@@ -104,21 +116,23 @@ class Run(object):
 
         return output
 
-    def _processArtifacts(self, component, provider):
+    def _processArtifacts(self, component, provider, provider_name = None):
+        if not provider_name:
+            provider_name = str(provider)
+
         artifacts = self.utils.getArtifacts(component)
         artifact_provider_list = []
-        logger.debug(provider)
-        if not str(provider) in artifacts:
-            raise Exception("Data for provider \"%s\" are not part of this app" % provider)
+        if not provider_name in artifacts:
+            raise Exception("Data for provider \"%s\" are not part of this app" % provider_name)
 
         dst_dir = os.path.join(self.utils.workdir, component)
         data = None
 
-        for artifact in artifacts[str(provider)]:
+        for artifact in artifacts[provider_name]:
             if "inherit" in artifact:
                 logger.debug("Inheriting from %s", artifact["inherit"])
                 for item in artifact["inherit"]:
-                    inherited_artifacts, _ = self._processArtifacts(component, item)
+                    inherited_artifacts, _ = self._processArtifacts(component, provider, item)
                     artifact_provider_list += inherited_artifacts
                 continue
             artifact_path = self.utils.sanitizePath(artifact)
@@ -141,11 +155,12 @@ class Run(object):
         provider_class = self.plugin.getProvider(self.params.provider)
         dst_dir = os.path.join(self.utils.tmpdir, component) #FIXME this should be .workdir
         provider = provider_class(self.params.getValues(component), dst_dir, self.dryrun)
-        provider.artifacts, dst_dir = self._processArtifacts(component, provider)
         if provider:
             logger.info("Using provider %s for component %s", self.params.provider, component)
         else:
             raise Exception("Something is broken - couldn't get the provider")
+
+        provider.artifacts, dst_dir = self._processArtifacts(component, provider)
 
         try:
             provider.init()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-anymarkup
+anymarkup>=0.4.1


### PR DESCRIPTION
By this commit, `atomicapp` is able to deploy simple app to openshift

```
[vpavlin@dhcp-30-155 ~/devel/upstream/goern-nulecule/examples/helloapache(feature/example-openshift-provider)]
$ osc --config=admin.kubeconfig get pods
POD       IP        CONTAINER(S)   IMAGE(S)   HOST      LABELS    STATUS    CREATED   MESSAGE
[vpavlin@dhcp-30-155 ~/devel/upstream/goern-nulecule/examples/helloapache(feature/example-openshift-provider)]
$ atomicapp run .
2015-05-19 12:24:54,205 - atomicapp.utils - INFO - Artifacts for helloapache-app present for these providers: openshift
2015-05-19 12:24:54,207 - atomicapp.utils - INFO - Using temporary directory /tmp/appent-helloapache-appRRAdKB
2015-05-19 12:24:54,211 - atomicapp.run - INFO - Using provider openshift for component helloapache-app
2015-05-19 12:24:54,212 - openshift - INFO - Calling: /home/vpavlin/bin/osc --config=admin.kubeconfig create -f /tmp/appent-helloapache-appRRAdKB/helloapache-app/artifacts/openshift/hello-apache-pod.json
pods/helloapache
[vpavlin@dhcp-30-155 ~/devel/upstream/goern-nulecule/examples/helloapache(feature/example-openshift-provider)]
$ osc --config=admin.kubeconfig get pods
POD           IP           CONTAINER(S)   IMAGE(S)       HOST                                      LABELS            STATUS    CREATED     MESSAGE
helloapache   172.17.0.4                                 dhcp-30-155.brq.redhat.com/10.34.30.155   app=helloapache   Running   3 seconds   
                           helloapache    centos/httpd 
```
Tested on
https://github.com/goern/atomicapp-spec/tree/feature/example-openshift-provider/examples/helloapache

Support for templates is mostly there, but is currently blocked by an issue (potentially) in `anymarkup`: https://github.com/bkabrda/anymarkup/issues/3