### PR TITLE
Raise exception rather than log warning on unimplemented provider init()

### DIFF
--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -34,7 +34,7 @@ class Provider(object):
             self.container = True
 
     def init(self):
-        logger.warning("This is default 'init()' method, consider implementing provider specific one.")
+        raise NotImplementedError()
 
     def deploy(self):
         raise NotImplementedError()

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -1,13 +1,9 @@
 from atomicapp.plugin import Provider, ProviderFailedException
 
-<<<<<<< HEAD
-import os, subprocess
-=======
 from collections import OrderedDict
 import os, anymarkup, subprocess
 from distutils.spawn import find_executable
 
->>>>>>> Implement simple working openshift provider
 import logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #98 - although I think warning is ok, the truth is there is no unused init in providers at the moment, so we can safely assume it should/will be used in every provider