### PR TITLE
Answer kubectl

### DIFF
--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -21,17 +21,45 @@ class KubernetesProvider(Provider):
 
         logger.info("Using namespace %s", self.namespace)
         if self.container:
-            self.kubectl = "/host/usr/bin/kubectl"
+            self.kubectl = self._findKubectl("/host")
             if not os.path.exists("/etc/kubernetes"):
                 if self.dryrun:
                     logger.info("DRY-RUN: link /etc/kubernetes from /host/etc/kubernetes")
                 else:
                     os.symlink("/host/etc/kubernetes", "/etc/kubernetes")
+        else:
+            self.kubectl = self._findKubectl()
 
         if not self.dryrun:
             if not os.access(self.kubectl, os.X_OK):
                 raise ProviderFailedException("Command: "+self.kubectl+" not found")
 
+    def _findKubectl(self, prefix=""):
+        """
+        Determine the path to the kubectl program on the host.
+        1) Check the config for a provider_cli in the general section
+           remember to add /host prefix
+        2) Search /usr/bin:/usr/local/bin
+
+        Use the first valid value found
+        """
+
+        test_paths = ['/usr/bin/kubectl', '/usr/local/bin/kubectl']
+        if self.config.get("provider_cli"):
+            logger.info("caller gave provider_cli: " + self.config.get("provider_cli"))
+            test_paths.insert(0, self.config.get("provider_cli"))
+
+        for path in test_paths:
+            test_path = prefix + path
+            logger.info("trying kubectl at " + test_path)
+            kubectl = test_path
+            if os.access(kubectl, os.X_OK):
+                logger.info("found kubectl at " + test_path)
+                return kubectl
+
+        raise "No kubectl found in %s" % ":".join(test_paths)
+
+                             
     def _callK8s(self, path):
         cmd = [self.kubectl, "create", "-f", path, "--namespace=%s" % self.namespace]
 

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -44,6 +44,10 @@ class KubernetesProvider(Provider):
         Use the first valid value found
         """
 
+        if self.dryrun:
+            # Testing env does not have kubectl in it
+            return "/usr/bin/kubectl"
+        
         test_paths = ['/usr/bin/kubectl', '/usr/local/bin/kubectl']
         if self.config.get("provider_cli"):
             logger.info("caller gave provider_cli: " + self.config.get("provider_cli"))
@@ -57,7 +61,7 @@ class KubernetesProvider(Provider):
                 logger.info("found kubectl at " + test_path)
                 return kubectl
 
-        raise "No kubectl found in %s" % ":".join(test_paths)
+        raise ProviderFailedException("No kubectl found in %s" % ":".join(test_paths)
 
                              
     def _callK8s(self, path):

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -61,7 +61,7 @@ class KubernetesProvider(Provider):
                 logger.info("found kubectl at " + test_path)
                 return kubectl
 
-        raise ProviderFailedException("No kubectl found in %s" % ":".join(test_paths)
+        raise ProviderFailedException("No kubectl found in %s" % ":".join(test_paths))
 
                              
     def _callK8s(self, path):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def _install_requirements():
     return requirements
 
 setup(name='atomicapp',
-      version='0.1',
+      version='0.1.6',
       description='A tool to install and run Nulecule apps',
       author='Vaclav Pavlin',
       author_email='vpavlin@redhat.com',
@@ -29,5 +29,5 @@ setup(name='atomicapp',
           'console_scripts': ['atomicapp=atomicapp.cli.main:main'],
       },
       packages=find_packages(),
-      install_requires=_install_requirements(),
+      install_requires=['anymarkup>=0.4.1']
 )


### PR DESCRIPTION
This change has two effects:

1) ````python setup.py bdist_rpm```` works, to create an RPM of atomicapp
2) (and more significantly) allow the caller to provide [general] provider_cli to override the default CLI path for a provider (kubernetes in this case)

This should allow for running an atomicapp on a Kubernetes Dev/Test environment in which the ````kubectl```` command is inside ````kubernetes/cluster/kubectl.sh``