### PR TITLE
Init artifacts - artifact list for kubernetes was not re-initialized for each component

### DIFF
--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -9,12 +9,12 @@ logger = logging.getLogger(__name__)
 
 class KubernetesProvider(Provider):
     key = "kubernetes"
-    namespace = "default"
-
-    kube_order = OrderedDict([("service", None), ("rc", None), ("pod", None)]) #FIXME
-    kubectl = "/usr/bin/kubectl"
 
     def init(self):
+        self.namespace = "default"
+
+        self.kube_order = OrderedDict([("service", None), ("rc", None), ("pod", None)]) #FIXME
+
         logger.debug("Given config: %s", self.config)
         if self.config.get("namespace"):
             self.namespace = self.config.get("namespace");

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def _install_requirements():
     return requirements
 
 setup(name='atomicapp',
-      version='0.1.6',
+      version='0.1.9',
       description='A tool to install and run Nulecule apps',
       author='Vaclav Pavlin',
       author_email='vpavlin@redhat.com',


### PR DESCRIPTION
The kubernetes namespace, kube_order and kubctl values were created as class variables.

The kube_order was later used as the "artifiacts" set for creating components., but was not reset when the KubernetesProvider.init() function executed.

This change places those values as instance variables and initializes them in init()