### PR TITLE
remove 5000 port and add python-setuptools from DockerFiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,31 @@ FROM centos:centos7
 
 MAINTAINER Vaclav Pavlin <vpavlin@redhat.com>
 
-RUN echo -e "[epel]\nname=epel\nenabled=1\nbaseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/\ngpgcheck=0" > /etc/yum.repos.d/epel.repo
+WORKDIR /opt/atomicapp
 
-RUN yum install -y --setopt=tsflags=nodocs python-pip docker && \
-    yum clean all
-
+# add all of Atomic App's files to the container image
 ADD atomicapp/ /opt/atomicapp/atomicapp/
 ADD setup.py /opt/atomicapp/
 ADD requirements.txt /opt/atomicapp/
 
-WORKDIR /opt/atomicapp
+# add EPEL repo for pip
+RUN echo -e "[epel]\nname=epel\nenabled=1\nbaseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/\ngpgcheck=0" > /etc/yum.repos.d/epel.repo
 
-RUN pip install .
+# lets install pip, and gcc for the native extensions
+# and remove all after use
+RUN yum install -y --setopt=tsflags=nodocs python-pip python-setuptools docker gcc && \
+    python setup.py install && \
+    pip install -r ./requirements.txt && \
+    yum remove -y gcc cpp glibc-devel glibc-headers kernel-headers libmpc mpfr python-pip && \
+    yum clean all
 
 WORKDIR /atomicapp
 VOLUME /atomicapp
 
-LABEL RUN docker run -it --rm --privileged --net=host -v `pwd`:/atomicapp -v /run:/run -v /:/host --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v run /atomicapp
-LABEL STOP docker run -it --rm --privileged --net=host -v `pwd`:/atomicapp -v /run:/run -v /:/host --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE -v stop /atomicapp
-LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v `pwd`:/atomicapp -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE -v install --destination /atomicapp /application-entity
+LABEL RUN  docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp
+LABEL STOP docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp
+LABEL INSTALL docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity
 
+
+# the entrypoint 
 ENTRYPOINT ["/usr/bin/atomicapp"]
-

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,23 +1,32 @@
 FROM fedora
-MAINTAINER langdon <langdon@fedoraproject.org>
-#Derived from Vaclav Pavlin <vpavlin@redhat.com>; https://github.com/vpavlin/atomicapp-run
 
-RUN yum -y install python python-pip docker && \
-    yum update -y && \
-    yum clean all
-
-ADD requirements.txt /opt/atomicapp/
-ADD setup.py /opt/atomicapp/
-ADD atomicapp/ /opt/atomicapp/atomicapp/
+MAINTAINER Vaclav Pavlin <vpavlin@redhat.com>
 
 WORKDIR /opt/atomicapp
-RUN python setup.py install
 
-WORKDIR /application-entity
-VOLUME /application-entity/answers.conf
+# add all of Atomic App's files to the container image
+ADD atomicapp/ /opt/atomicapp/atomicapp/
+ADD setup.py /opt/atomicapp/
+ADD requirements.txt /opt/atomicapp/
 
-LABEL RUN docker run -it --rm --privileged --net=host -v ${PWD}:/atomicapp -v /run:/run -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE atomicapp -v run /atomicapp
-LABEL INSTALL docker run --rm -it --privileged -v /run:/run -v ${PWD}:/atomicapp -v /:/host -v ${PWD}/answers.conf:/application-entity/answers.conf -e IMAGE=IMAGE -e NAME=NAME --name NAME IMAGE atomicapp -v install --path /atomicapp /application-entity
+# add EPEL repo for pip
+RUN echo -e "[epel]\nname=epel\nenabled=1\nbaseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/\ngpgcheck=0" > /etc/yum.repos.d/epel.repo
 
-CMD atomicapp -h
+# lets install pip, and gcc for the native extensions
+# and remove all after use
+RUN yum install -y --setopt=tsflags=nodocs python-pip python-setuptools docker gcc && \
+    python setup.py install && \
+    pip install -r ./requirements.txt && \
+    yum remove -y gcc cpp glibc-devel glibc-headers kernel-headers libmpc mpfr python-pip && \
+    yum clean all
 
+WORKDIR /atomicapp
+VOLUME /atomicapp
+
+LABEL RUN  docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp
+LABEL STOP docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp
+LABEL INSTALL docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity
+
+
+# the entrypoint 
+ENTRYPOINT ["/usr/bin/atomicapp"]


### PR DESCRIPTION
1) Reverting the code for EXPOSE port in Dockerfile
As rest implimentation is not possible for end to end integration with atomic and cockpit So, removing
EXPOSE 5000


2)python-setuptools need to be installed to fix No module named pkg_resources error.
atomic run --opt2='--answers=/home/development/atomic_jsonbrooks/nulecule/examples/tmp/answers.conf' submod/guestbookphp-app
docker run -it --rm ${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name ${NAME} -e NAME=${NAME} -e IMAGE=${IMAGE} ${IMAGE} -v ${OPT2} run ${OPT3} /atomicapp
Traceback (most recent call last):
  File "/usr/bin/atomicapp", line 5, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
