### PR TITLE
Support answers-format option in install

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -37,6 +37,7 @@ class CLI():
 
         self.parser.add_argument("--dry-run", dest="dryrun", default=False, action="store_true", help="Don't actually call provider. The commands that should be run will be sent to stdout but not run.")
         self.parser.add_argument("-a", "--answers", dest="answers", default=os.path.join(os.getcwd(), ANSWERS_FILE), help="Path to %s" % ANSWERS_FILE)
+        self.parser.add_argument("--answers-format", dest="answers_format", default=ANSWERS_FILE_SAMPLE_FORMAT, help="The format for the answers.conf.sample file.Default is 'ini', Valid formats are 'ini', 'json', 'xml', 'yaml'.")
 
         subparsers = self.parser.add_subparsers(dest="action")
 
@@ -49,7 +50,6 @@ class CLI():
         parser_install = subparsers.add_parser("install")
 
         parser_install.add_argument("--no-deps", dest="nodeps", default=False, action="store_true", help="Skip pulling dependencies of the app")
-        parser_install.add_argument("--answers-format", dest="answers_format", default=ANSWERS_FILE_SAMPLE_FORMAT, help="The format for the answers.conf.sample file.Default is 'ini', Valid formats are 'ini', 'json', 'xml', 'yaml'.")
         parser_install.add_argument("-u", "--update", dest="update", default=False, action="store_true", help="Re-pull images and overwrite existing files")
         parser_install.add_argument("--destination", dest="target_path", default=None, help="Destination directory for install")
         parser_install.add_argument("APP",  help="Application to run. This is a container image or a path that contains the metadata describing the whole application.")

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -9,7 +9,7 @@ from argparse import RawDescriptionHelpFormatter
 import logging
 
 from atomicapp import set_logging
-from atomicapp.constants import ANSWERS_FILE, __ATOMICAPPVERSION__, __NULECULESPECVERSION__
+from atomicapp.constants import ANSWERS_FILE, __ATOMICAPPVERSION__, __NULECULESPECVERSION__, ANSWERS_FILE_SAMPLE_FORMAT
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ class CLI():
         parser_install = subparsers.add_parser("install")
 
         parser_install.add_argument("--no-deps", dest="nodeps", default=False, action="store_true", help="Skip pulling dependencies of the app")
+        parser_install.add_argument("--answers-format", dest="answers_format", default=ANSWERS_FILE_SAMPLE_FORMAT, help="The format for the answers.conf.sample file.Default is 'ini', Valid formats are 'ini', 'json', 'xml', 'yaml'.")
         parser_install.add_argument("-u", "--update", dest="update", default=False, action="store_true", help="Re-pull images and overwrite existing files")
         parser_install.add_argument("--destination", dest="target_path", default=None, help="Destination directory for install")
         parser_install.add_argument("APP",  help="Application to run. This is a container image or a path that contains the metadata describing the whole application.")

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -9,6 +9,7 @@ PARAMS_KEY="params"
 MAIN_FILE="Nulecule"
 ANSWERS_FILE="answers.conf"
 ANSWERS_FILE_SAMPLE="answers.conf.sample"
+ANSWERS_FILE_SAMPLE_FORMAT='ini'
 WORKDIR=".workdir"
 
 DEFAULT_PROVIDER="kubernetes"

--- a/atomicapp/install.py
+++ b/atomicapp/install.py
@@ -9,7 +9,7 @@ import logging
 
 from nulecule_base import Nulecule_Base
 from utils import Utils, printStatus, printAnswerFile
-from constants import APP_ENT_PATH, MAIN_FILE
+from constants import APP_ENT_PATH, MAIN_FILE, ANSWERS_FILE_SAMPLE_FORMAT
 
 logger = logging.getLogger(__name__)
 
@@ -19,13 +19,13 @@ class Install(object):
     answers_file = None
     docker_cli = "docker"
 
-    def __init__(self, answers, APP, nodeps = False, update = False, target_path = None, dryrun = False, **kwargs):
+    def __init__(self, answers, APP, nodeps = False, update = False, target_path = None, dryrun = False, answers_format = ANSWERS_FILE_SAMPLE_FORMAT, **kwargs):
         self.dryrun = dryrun
         self.kwargs = kwargs
 
         app = APP #FIXME
 
-        self.nulecule_base = Nulecule_Base(nodeps, update, target_path, dryrun)
+        self.nulecule_base = Nulecule_Base(nodeps, update, target_path, dryrun, answers_format)
 
         if os.path.exists(app):
             logger.info("App path is %s, will be populated to %s", app, target_path)

--- a/atomicapp/install.py
+++ b/atomicapp/install.py
@@ -147,7 +147,7 @@ class Install(object):
 
         printAnswerFile(json.dumps(answerContent))
         printStatus("Install Successful.")
-        return values
+        return None
 
     def _installDependencies(self):
         values = {}

--- a/atomicapp/nulecule_base.py
+++ b/atomicapp/nulecule_base.py
@@ -4,7 +4,7 @@ import logging
 import copy
 import subprocess
 
-from constants import MAIN_FILE, GLOBAL_CONF, DEFAULT_PROVIDER, PARAMS_KEY, ANSWERS_FILE, DEFAULT_ANSWERS, ANSWERS_FILE_SAMPLE, __NULECULESPECVERSION__
+from constants import MAIN_FILE, GLOBAL_CONF, DEFAULT_PROVIDER, PARAMS_KEY, ANSWERS_FILE, DEFAULT_ANSWERS, ANSWERS_FILE_SAMPLE, __NULECULESPECVERSION__, ANSWERS_FILE_SAMPLE_FORMAT
 
 from utils import Utils, printStatus, printErrorStatus
 
@@ -23,6 +23,7 @@ class Nulecule_Base(object):
     ask = False
     write_sample_answers = False
     docker_cli = None
+    answer_file_format = ANSWERS_FILE_SAMPLE_FORMAT
 
     @property
     def app(self):
@@ -54,13 +55,14 @@ class Nulecule_Base(object):
 
         self.__target_path = path
 
-    def __init__(self, nodeps=False, update=False, target_path=None, dryrun = False):
+    def __init__(self, nodeps=False, update=False, target_path=None, dryrun = False, file_format = ANSWERS_FILE_SAMPLE_FORMAT):
         self.target_path = target_path
         self.nodeps = Utils.isTrue(nodeps)
         self.update = Utils.isTrue(update)
         self.override = Utils.isTrue(False)
         self.dryrun = dryrun
         self.docker_cli = Utils.getDockerCli(dryrun)
+        self.answer_file_format = file_format
 
     def loadParams(self, data = None):
         if type(data) == dict:
@@ -215,7 +217,7 @@ class Nulecule_Base(object):
 
 
     def writeAnswers(self, path):
-        anymarkup.serialize_file(self.answers_data, path, format='ini')
+        anymarkup.serialize_file(self.answers_data, path, format=self.answer_file_format)
 
     def writeAnswersSample(self):
         path = os.path.join(self.target_path, ANSWERS_FILE_SAMPLE)

--- a/atomicapp/nulecule_base.py
+++ b/atomicapp/nulecule_base.py
@@ -217,6 +217,7 @@ class Nulecule_Base(object):
 
 
     def writeAnswers(self, path):
+        logger.debug("writing %s to %s with format %s", self.answers_data, path , self.answer_file_format)
         anymarkup.serialize_file(self.answers_data, path, format=self.answer_file_format)
 
     def writeAnswersSample(self):

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -7,7 +7,7 @@ import logging
 
 from nulecule_base import Nulecule_Base
 from utils import Utils, printStatus, printErrorStatus
-from constants import GLOBAL_CONF, DEFAULT_PROVIDER, MAIN_FILE
+from constants import GLOBAL_CONF, DEFAULT_PROVIDER, MAIN_FILE, ANSWERS_FILE_SAMPLE_FORMAT
 from plugin import Plugin, ProviderFailedException
 from install import Install
 
@@ -32,7 +32,7 @@ class Run(object):
     answers_output = None
     kwargs = None
 
-    def __init__(self, answers, APP, dryrun = False, debug = False, stop = False, **kwargs):
+    def __init__(self, answers, APP, dryrun = False, debug = False, stop = False, answers_format = ANSWERS_FILE_SAMPLE_FORMAT, **kwargs):
 
         self.debug = debug
         self.dryrun = dryrun
@@ -60,11 +60,11 @@ class Run(object):
         else:
             if not self.app_path:
                 self.app_path = os.getcwd()
-            install = Install(answers, APP, dryrun = dryrun, target_path = self.app_path)
+            install = Install(answers, APP, dryrun = dryrun, target_path = self.app_path, answers_format=answers_format)
             install.install()
             printStatus("Install Successful.")
 
-        self.nulecule_base = Nulecule_Base(target_path=self.app_path, dryrun = dryrun)
+        self.nulecule_base = Nulecule_Base(target_path=self.app_path, dryrun = dryrun, file_format=answers_format)
         if "ask" in kwargs:
             self.nulecule_base.ask = kwargs["ask"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ __author__ = "goern"
 
 import os, sys, logging
 
-import pytest
+import pytest , json
 
 import atomicapp.cli.main
 
@@ -44,8 +44,15 @@ class TestCLISuite(object):
         atomicapp.cli.main.main()
         sys.argv = saved_args
 
+    def is_json(self, myjson):
+      try:
+        json_object = json.loads(myjson)
+      except ValueError, e:
+        return False
+      return True
+
     # lets test if we can run a simple atomicapp
-    def test_with_helloapache(self):
+    def test_run_with_helloapache(self):
         # prepare the atomicapp command to dry run
         command = [
             "main.py",
@@ -60,6 +67,27 @@ class TestCLISuite(object):
             self.exec_cli(command)
 
         assert exec_info.value.code == 0
+
+    # lets test if we can install a simple atomicapp
+    def test_install_with_helloapache(self):
+        # prepare the atomicapp command to dry run
+        command = [
+            "main.py",
+            "--verbose",
+            "--answers-format=json",
+            "--dry-run",
+            "install",
+            tests_root + 'cached_nulecules/helloapache/'
+        ]
+
+        # run the command and check if it was successful
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        json_data=open(tests_root + "cached_nulecules/helloapache/answers.conf.sample").read()
+
+        assert exec_info.value.code == 0
+        assert self.is_json(json_data)
 
     # test it with the famous WordPress Nulecule
     # wordpress-centos7-atomicapp


### PR DESCRIPTION
support answers-format option in install
so that we can define the format of answers.conf.sample file.

default = 'ini'
Valid formats are 'ini', 'json', 'xml', 'yaml'.

example:
atomicapp -v install --answers-format="json"  submod/guestbookphp-app

Required for https://github.com/cockpit-project/cockpit/pull/2474
