### PR TITLE
make install return values instead of None

### DIFF
--- a/atomicapp/install.py
+++ b/atomicapp/install.py
@@ -18,6 +18,7 @@ class Install(object):
     params = None
     answers_file = None
     docker_cli = "docker"
+    answers_file_values = {}
 
     def __init__(self, answers, APP, nodeps = False, update = False, target_path = None, dryrun = False, answers_format = ANSWERS_FILE_SAMPLE_FORMAT, **kwargs):
         self.dryrun = dryrun
@@ -133,14 +134,13 @@ class Install(object):
         self.nulecule_base.checkAllArtifacts()
 
         printStatus("Loading Nulecule file.")
-        values = {}
         if not self.nulecule_base.nodeps:
             logger.info("Installing dependencies for %s", self.nulecule_base.app_id)
-            values = self._installDependencies()
+            self.answers_file_values = self._installDependencies()
             printStatus("All dependencies installed successfully.")
 
-        logger.debug(values)
-        answerContent = self.nulecule_base.loadAnswers(values)
+        logger.debug(self.answers_file_values)
+        answerContent = self.nulecule_base.loadAnswers(self.answers_file_values)
         logger.debug(self.nulecule_base.answers_data)
         if self.nulecule_base.write_sample_answers:
             self.nulecule_base.writeAnswersSample()
@@ -172,7 +172,8 @@ class Install(object):
                 printStatus("Pulling %s ..." % image_name)
                 component_app = Install(self.nulecule_base.answers_data, image_name, self.nulecule_base.nodeps, 
                                         self.nulecule_base.update, component_path, self.dryrun)
-                values = Utils.update(values, component_app.install())
+                component_app.install()
+                values = Utils.update(values, component_app.answers_file_values)
                 printStatus("Component %s installed successfully."%component)
                 logger.debug("Component installed into %s", component_path)
             else:


### PR DESCRIPTION
@goern 
Intsall.install() method should return values instead of None
I am reverting my change. 

Also refactoring a bit so that instead of returning values from install() we get it that values from a field called answers_file_values


I was able to see this error on a fresh setup.If you keep testing fom same folder this error wont show up.
2015-07-25 12:15:39,831 - atomicapp.utils - INFO - atomicapp.status.info.message=Install Successful.
Traceback (most recent call last):
  File "/usr/bin/atomicapp", line 9, in <module>
    load_entry_point('atomicapp==0.1.9', 'console_scripts', 'atomicapp')()
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.9-py2.7.egg/atomicapp/cli/main.py", line 91, in main
    cli.run()
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.9-py2.7.egg/atomicapp/cli/main.py", line 72, in run
    args.func(args)
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.9-py2.7.egg/atomicapp/cli/main.py", line 18, in cli_install
    sys.exit(install.install() != None)
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.9-py2.7.egg/atomicapp/install.py", line 139, in install
    values = self._installDependencies()
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.9-py2.7.egg/atomicapp/install.py", line 175, in _installDependencies
    values = Utils.update(values, component_app.install())
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.9-py2.7.egg/atomicapp/utils.py", line 155, in update
    for key, val in new_dict.iteritems():
AttributeError: 'NoneType' object has no attribute 'iteritems'
