### PR TITLE
Fix a logic bug

### DIFF
--- a/atomicapp/nulecule_base.py
+++ b/atomicapp/nulecule_base.py
@@ -93,9 +93,9 @@ class Nulecule_Base(object):
             raise Exception("%s not found: %s" % (MAIN_FILE, path))
 
         self.mainfile_data = anymarkup.parse_file(path)
-        logger.debug("Setting app id to %s", self.mainfile_data["id"])
         if "id" in self.mainfile_data:
             self.app_id = self.mainfile_data["id"]
+	    logger.debug("Setting app id to %s", self.mainfile_data["id"])
         else:
             raise Exception ("Missing ID in %s" % self.mainfile_data)
 


### PR DESCRIPTION
if the id is not found the exception won't be raised by the expected
code for it but by the access to the dict in the message before it

Also testing my workflow with github I'm not familiar with TBH