### PR TITLE
Don't use /host string directly in code

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -17,6 +17,7 @@ ANSWERS_FILE_SAMPLE = "answers.conf.sample"
 ANSWERS_FILE_SAMPLE_FORMAT = 'ini'
 WORKDIR = ".workdir"
 LOCK_FILE = "/run/lock/atomicapp.lock"
+HOST_DIR = "/host"
 
 DEFAULT_PROVIDER = "kubernetes"
 DEFAULT_NAMESPACE = "default"

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -6,6 +6,8 @@ import os
 import imp
 
 import logging
+from utils import Utils
+from constants import HOST_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +33,7 @@ class Provider(object):
         self.config = config
         self.path = path
         self.dryrun = dryrun
-        if os.path.exists("/host"):
+        if Utils.getRoot() == HOST_DIR:
             self.container = True
 
     def init(self):

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -32,7 +32,7 @@ class KubernetesProvider(Provider):
                 if self.dryrun:
                     logger.info("DRY-RUN: link %s from %s%s" % (kube_conf_path, HOST_DIR, kube_conf_path))
                 else:
-                    os.symlink(os.path.join(Utils.getRoot, kube_conf_path.lstrip("/"), kube_conf_path))
+                    os.symlink(os.path.join(Utils.getRoot(), kube_conf_path.lstrip("/")), kube_conf_path)
         else:
             self.kubectl = self._findKubectl()
 

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -1,5 +1,6 @@
 from atomicapp.plugin import Provider, ProviderFailedException
-from atomicapp.utils import printErrorStatus
+from atomicapp.utils import printErrorStatus, Utils
+from atomicapp.constants import HOST_DIR
 from collections import OrderedDict
 import os
 import anymarkup
@@ -25,12 +26,13 @@ class KubernetesProvider(Provider):
 
         logger.info("Using namespace %s", self.namespace)
         if self.container:
-            self.kubectl = self._findKubectl("/host")
-            if not os.path.exists("/etc/kubernetes"):
+            self.kubectl = self._findKubectl(Utils.getRoot())
+            kube_conf_path = "/etc/kubernetes"
+            if not os.path.exists(kube_conf_path):
                 if self.dryrun:
-                    logger.info("DRY-RUN: link /etc/kubernetes from /host/etc/kubernetes")
+                    logger.info("DRY-RUN: link %s from %s%s" % (kube_conf_path, HOST_DIR, kube_conf_path))
                 else:
-                    os.symlink("/host/etc/kubernetes", "/etc/kubernetes")
+                    os.symlink(os.path.join(Utils.getRoot, kube_conf_path.lstrip("/"), kube_conf_path))
         else:
             self.kubectl = self._findKubectl()
 

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -1,4 +1,5 @@
 from atomicapp.plugin import Provider, ProviderFailedException
+from atomicapp.constants import HOST_DIR
 
 from collections import OrderedDict
 import os
@@ -9,7 +10,6 @@ from distutils.spawn import find_executable
 import logging
 
 logger = logging.getLogger(__name__)
-
 
 class OpenShiftProvider(Provider):
     key = "openshift"
@@ -23,11 +23,11 @@ class OpenShiftProvider(Provider):
         if self.container and not self.cli:
             host_path = []
             for path in os.environ.get("PATH").split(":"):
-                host_path.append("/host%s" % path)
+                host_path.append("%s%s" % (HOST_DIR, path))
             self.cli = find_executable(self.cli_str, path=":".join(host_path))
             if not self.cli:
                 # if run as non-root we need a symlink in the container
-                os.symlink("/host/usr/bin/openshift", "/usr/bin/oc")
+                os.symlink("%s/usr/bin/openshift" % HOST_DIR, "/usr/bin/oc")
                 self.cli = "/usr/bin/oc"
 
         if not self.cli or not os.access(self.cli, os.X_OK):
@@ -38,7 +38,7 @@ class OpenShiftProvider(Provider):
         if "openshiftconfig" in self.config:
             self.config_file = self.config["openshiftconfig"]
             if self.container:
-                self.config_file = os.path.join("/host", self.config_file.lstrip("/"))
+                self.config_file = os.path.join(HOST_DIR, self.config_file.lstrip("/"))
         else:
             logger.warning("Configuration option 'openshiftconfig' not found")
 

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -1,5 +1,5 @@
 from atomicapp.plugin import Provider, ProviderFailedException
-from atomicapp.constants import HOST_DIR
+from utils import Utils
 
 from collections import OrderedDict
 import os
@@ -23,11 +23,11 @@ class OpenShiftProvider(Provider):
         if self.container and not self.cli:
             host_path = []
             for path in os.environ.get("PATH").split(":"):
-                host_path.append("%s%s" % (HOST_DIR, path))
+                host_path.append(os.path.join(Utils.getRoot(), path.lstrip("/")))
             self.cli = find_executable(self.cli_str, path=":".join(host_path))
             if not self.cli:
                 # if run as non-root we need a symlink in the container
-                os.symlink("%s/usr/bin/openshift" % HOST_DIR, "/usr/bin/oc")
+                os.symlink(os.path.join(Utils.getRoot(), "usr/bin/oc"), "/usr/bin/oc")
                 self.cli = "/usr/bin/oc"
 
         if not self.cli or not os.access(self.cli, os.X_OK):
@@ -38,7 +38,7 @@ class OpenShiftProvider(Provider):
         if "openshiftconfig" in self.config:
             self.config_file = self.config["openshiftconfig"]
             if self.container:
-                self.config_file = os.path.join(HOST_DIR, self.config_file.lstrip("/"))
+                self.config_file = os.path.join(Utils.getRoot(), self.config_file.lstrip("/"))
         else:
             logger.warning("Configuration option 'openshiftconfig' not found")
 

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -8,7 +8,7 @@ from distutils.spawn import find_executable
 
 import logging
 
-from constants import APP_ENT_PATH, EXTERNAL_APP_DIR, WORKDIR
+from constants import APP_ENT_PATH, EXTERNAL_APP_DIR, WORKDIR, HOST_DIR
 
 __all__ = ('Utils')
 
@@ -191,7 +191,7 @@ class Utils(object):
 
     @staticmethod
     def getRoot():
-        if os.path.isdir("/host"):
-            return "/host/"
+        if os.path.isdir(HOST_DIR):
+            return HOST_DIR
         else:
             return "/"


### PR DESCRIPTION
This patch replaces all `/host` occurrences in the code with either `HOST_DIR` constant, or call to a `Utils.getRoot()` 