### PR TITLE
Providers: Update link to Nulecule's paramsObject

### DIFF
--- a/Providers.asciidoc
+++ b/Providers.asciidoc
@@ -80,7 +80,7 @@ As of 0.1.0 of Atomic App, only
 http://docs.openshift.org/latest/dev_guide/templates.html[OpenShift templates] will be
 preprocessed by Atomic App during the run phase: parameters within a
 template file will be replaced by the
-https://github.com/projectatomic/nulecule/blob/master/spec/0.0.2/README.md#paramsObject[params]
+https://github.com/projectatomic/nulecule/blob/master/spec/README.md#paramsObject[params]
 supplied to Atomic App, names need to match.
 
 ==== configuration values


### PR DESCRIPTION
Catch up with projectatomic/nulecule@ab067ff5 (Refactor spec
directory, 2015-07-09).  There's a tradeoff here between a permanent
link to the dead v0.0.2 spec and a link to the live current spec.  The
former won't break (assuming no further changes like ab067ff5), but it
would require manual updates whenever atomicapp bumps its Nulecule
version.  The live link won't need to be bumped, but it may point at a
version of the spec that doesn't match the atomicapp implementation.

I've gone with the live link here, but I'm happy to reroll if the
maintainers want something that they need to explicitly bump.