### PR TITLE
Workaround docker create bug. Closes #194

### DIFF
--- a/atomicapp/install.py
+++ b/atomicapp/install.py
@@ -72,7 +72,8 @@ class Install(object):
                           ''.join(random.sample(string.letters, 6)))
         logger.debug("Creating a container with name %s", name)
 
-        create = [self.docker_cli, "create", "--name", name, image, "nop"]
+        # Workaround docker bug BZ1252168 by using run instead of create
+        create = [self.docker_cli, "run", "--name", name, "--entrypoint", "/bin/true", image]
         logger.debug(" ".join(create))
         subprocess.call(create)
         cp = [self.docker_cli, "cp", "%s:/%s" % (name, APP_ENT_PATH), self.utils.tmpdir]


### PR DESCRIPTION
There is a docker bug [1] that causes the *docker create* behavior
to be different than it was in the past. This is a workaround so that
we can move forward for now.

[1] - https://bugzilla.redhat.com/show_bug.cgi?id=1252168