### PR TITLE
Remove EPEL repo as it isn't needed for Fedora

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -14,9 +14,6 @@ ADD atomicapp/ /opt/atomicapp/atomicapp/
 ADD setup.py /opt/atomicapp/
 ADD requirements.txt /opt/atomicapp/
 
-# add EPEL repo for pip
-RUN echo -e "[epel]\nname=epel\nenabled=1\nbaseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/\ngpgcheck=0" > /etc/yum.repos.d/epel.repo
-
 # lets install pip, and gcc for the native extensions
 # and remove all after use
 RUN dnf install -y --setopt=tsflags=nodocs python-pip python-setuptools docker gcc && \


### PR DESCRIPTION
```
...
Step 13 : ENTRYPOINT /usr/bin/atomicapp
 ---> Running in eae26db76568
 ---> 63cc5bea4c32
Removing intermediate container eae26db76568
Successfully built 63cc5bea4c32
```