### PR TITLE
Add --provider option

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -137,6 +137,12 @@ class CLI():
             help="A file which will contain anwsers provided in interactive mode")
 
         parser_run.add_argument(
+            "--provider",
+            dest="cli_provider",
+            choices=['docker', 'kubernetes', 'openshift'],
+            help="The provider to use. Overrides provider value in answerfile.")
+
+        parser_run.add_argument(
             "--ask",
             default=False,
             action="store_true",

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -187,6 +187,12 @@ class CLI():
 
         parser_stop = subparsers.add_parser("stop")
         parser_stop.add_argument(
+            "--provider",
+            dest="cli_provider",
+            choices=['docker', 'kubernetes', 'openshift'],
+            help="The provider to use. Overrides provider value in answerfile.")
+
+        parser_stop.add_argument(
             "APP",
             help=(
                 "Path to the directory where the Atomic App is installed or "

--- a/atomicapp/nulecule_base.py
+++ b/atomicapp/nulecule_base.py
@@ -60,7 +60,9 @@ class Nulecule_Base(object):
     @property
     def provider(self):
         config = self.get()
-        if "provider" in config:
+        if self.cli_provider:
+            return self.cli_provider
+        elif "provider" in config:
             return config["provider"]
         return self.__provider
 
@@ -79,7 +81,8 @@ class Nulecule_Base(object):
 
     def __init__(
             self, nodeps=False, update=False, target_path=None,
-            dryrun=False, file_format=ANSWERS_FILE_SAMPLE_FORMAT):
+            dryrun=False, file_format=ANSWERS_FILE_SAMPLE_FORMAT,
+            cli_provider=None):
         self.target_path = target_path
         self.nodeps = Utils.isTrue(nodeps)
         self.update = Utils.isTrue(update)
@@ -87,6 +90,7 @@ class Nulecule_Base(object):
         self.dryrun = dryrun
         self.docker_cli = Utils.getDockerCli(dryrun)
         self.answer_file_format = file_format
+        self.cli_provider = cli_provider
 
     def loadParams(self, data=None):
         if type(data) == dict:

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -58,6 +58,7 @@ class Run(object):
         self.dryrun = dryrun
         self.stop = stop
         self.kwargs = kwargs
+        self.cli_provider = None
 
         if "answers_output" in kwargs:
             self.answers_output = kwargs["answers_output"]

--- a/atomicapp/run.py
+++ b/atomicapp/run.py
@@ -62,6 +62,9 @@ class Run(object):
         if "answers_output" in kwargs:
             self.answers_output = kwargs["answers_output"]
 
+        if "cli_provider" in kwargs:
+            self.cli_provider = kwargs["cli_provider"]
+
         if os.environ and "IMAGE" in os.environ:
             self.app_path = APP
             APP = os.environ["IMAGE"]
@@ -87,7 +90,10 @@ class Run(object):
             printStatus("Install Successful.")
 
         self.nulecule_base = Nulecule_Base(
-            target_path=self.app_path, dryrun=dryrun, file_format=answers_format)
+            target_path=self.app_path,
+            dryrun=dryrun,
+            file_format=answers_format,
+            cli_provider=self.cli_provider)
         if "ask" in kwargs:
             self.nulecule_base.ask = kwargs["ask"]
 
@@ -191,7 +197,6 @@ class Run(object):
     def _processComponent(self, component, graph_item):
         logger.debug(
             "Processing component '%s' and graph item '%s'", component, graph_item)
-
         provider_class = self.plugin.getProvider(self.nulecule_base.provider)
         dst_dir = os.path.join(self.utils.workdir, component)
         provider = provider_class(
@@ -223,9 +228,6 @@ class Run(object):
         self.nulecule_base.loadAnswers(self.answers_file)
 
         self.nulecule_base.checkAllArtifacts()
-        config = self.nulecule_base.get()
-        if "provider" in config:
-            self.provider = config["provider"]
 
         self._dispatchGraph()
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,21 @@
+# Atomica App Command Line Interface (CLI)
+
+## Providers
+
+Providers may be specified using the `answers.conf` file or the `--provider <provider>` option. If not specified the kubernetes provider will be used by default.
+
+Sample `answers.conf` file specifying provider
+
+```
+[general]
+provider = openshift
+```
+
+Using the `--provider <provider>` option will  will override the provider in the answerfile.
+
+### Supported providers
+
+* kubernetes (default)
+* openshift
+* docker
+

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ Sample `answers.conf` file specifying provider
 provider = openshift
 ```
 
-Using the `--provider <provider>` option will  will override the provider in the answerfile.
+Using the `--provider <provider>` option will override the provider in the answerfile.
 
 ### Supported providers
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,4 @@
-# Atomica App Command Line Interface (CLI)
+# Atomic App Command Line Interface (CLI)
 
 ## Providers
 


### PR DESCRIPTION
The --provider option is constrained to supported providers.
Providers can be specified in answers.conf. If --provider opt
is specified it will be overridden. Otherwise the default provider
is used.

Resolves #171 