### PR TITLE
Updated pep8 ignore list

### DIFF
--- a/atomicapp/__init__.py
+++ b/atomicapp/__init__.py
@@ -19,6 +19,7 @@
 
 import logging
 
+
 def set_logging(name="atomicapp", level=logging.DEBUG):
     # create logger
     logger = logging.getLogger()

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -48,6 +48,7 @@ def cli_install(args):
     else:
         sys.exit(False)
 
+
 def cli_run(args):
     ae = Run(**vars(args))
 

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -23,6 +23,7 @@ Update the below LABELS if ATOMICAPPVERSION & NULECULESPECVERSION are updated:
 2) LABEL io.projectatomic.nulecule.specversion  in app Dockefile
 """
 
+
 def _get_version(path):
     try:
         with open(path) as f:

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -30,6 +30,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class OpenShiftProvider(Provider):
     key = "openshift"
     cli_str = "oc"

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ def _install_requirements():
     requirements = _get_requirements('requirements.txt')
     return requirements
 
+
 def _get_version():
     version = _get_requirements('VERSION')
     return version[0]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     flake8
 
 [flake8]
-ignore = E302,E41,E251,C901
+ignore = E41,E251,C901
 max-line-length = 160
 exclude = .git,.tox,tests
 max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     flake8
 
 [flake8]
-ignore = E226,E302,E41,E251,C901
+ignore = E302,E41,E251,C901
 max-line-length = 160
 exclude = .git,.tox,tests
 max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     flake8
 
 [flake8]
-ignore = E41,E251,C901
+ignore = E251,C901
 max-line-length = 160
 exclude = .git,.tox,tests
 max-complexity = 10


### PR DESCRIPTION
Three pep8 rules can actually be removed from the ignore list,

E226: missing whitespace around arithmetic operator, currently not applicable to any code base but certainly improves code visibility
E302: expected 2 blank lines, currently it was not consistent in code base, removing it from ignore list makes it consistent
E41: Seems to be a typo, did not find any information about it in [1] 

[1] http://pep8.readthedocs.org/en/latest/intro.html

Resolves #239 