### PR TITLE
Fixes processing multiple k8s resource artifacts

### DIFF
--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -154,8 +154,9 @@ class KubernetesProvider(Provider):
         :arg replicas: Replica size to scale to.
         """
         rname = self._resource_identity(path)
-        cmd = [self.kubectl, "scale", "rc", rname, "--replicas=0", "--namespace=%s" %
-               self.namespace]
+        cmd = [self.kubectl, "scale", "rc", rname,
+               "--replicas=%s" % str(replicas),
+               "--namespace=%s" % self.namespace]
 
         if self.dryrun:
             logger.info("DRY-RUN: %s", " ".join(cmd))

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class KubernetesProvider(Provider):
+
     """Operations for Kubernetes provider is implemented in this class.
     This class implements deploy, stop and undeploy of an atomicapp on
     Kubernetes provider.
@@ -120,11 +121,18 @@ class KubernetesProvider(Provider):
             data = None
             with open(os.path.join(self.path, artifact), "r") as fp:
                 logger.debug(os.path.join(self.path, artifact))
-                data = anymarkup.parse(fp)
+                try:
+                    data = anymarkup.parse(fp)
+                except Exception:
+                    msg = "Error processing %s artifcats, Error:" % os.path.join(
+                        self.path, artifact)
+                    printErrorStatus(msg)
+                    raise
             if "kind" in data:
                 self.k8s_manifests.append((data["kind"].lower(), artifact))
             else:
-                raise ProviderFailedException("Malformed kube file")
+                apath = os.path.join(self.path, artifact)
+                raise ProviderFailedException("Malformed kube file: %s" % apath)
 
     def _resource_identity(self, path):
         """Finds the Kubernetes resource name / identity from resource manifest

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -17,27 +17,30 @@
  along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from atomicapp.plugin import Provider, ProviderFailedException
-from atomicapp.utils import printErrorStatus, Utils
-from atomicapp.constants import HOST_DIR
-from collections import OrderedDict
-import os
 import anymarkup
+import logging
+import os
 import subprocess
 from subprocess import Popen, PIPE
-import logging
+
+from atomicapp.constants import HOST_DIR
+from atomicapp.plugin import Provider, ProviderFailedException
+from atomicapp.utils import printErrorStatus, Utils
 
 logger = logging.getLogger(__name__)
 
 
 class KubernetesProvider(Provider):
+    """Operations for Kubernetes provider is implemented in this class.
+    This class implements deploy, stop and undeploy of an atomicapp on
+    Kubernetes provider.
+    """
     key = "kubernetes"
 
     def init(self):
         self.namespace = "default"
 
-        self.kube_order = OrderedDict(
-            [("service", None), ("rc", None), ("pod", None)])  # FIXME
+        self.k8s_manifests = []
 
         logger.debug("Given config: %s", self.config)
         if self.config.get("namespace"):
@@ -45,7 +48,7 @@ class KubernetesProvider(Provider):
 
         logger.info("Using namespace %s", self.namespace)
         if self.container:
-            self.kubectl = self._findKubectl(Utils.getRoot())
+            self.kubectl = self._find_kubectl(Utils.getRoot())
             kube_conf_path = "/etc/kubernetes"
             if not os.path.exists(kube_conf_path):
                 if self.dryrun:
@@ -53,15 +56,14 @@ class KubernetesProvider(Provider):
                 else:
                     os.symlink(os.path.join(Utils.getRoot(), kube_conf_path.lstrip("/")), kube_conf_path)
         else:
-            self.kubectl = self._findKubectl()
+            self.kubectl = self._find_kubectl()
 
         if not self.dryrun:
             if not os.access(self.kubectl, os.X_OK):
                 raise ProviderFailedException("Command: " + self.kubectl + " not found")
 
-    def _findKubectl(self, prefix=""):
-        """
-        Determine the path to the kubectl program on the host.
+    def _find_kubectl(self, prefix=""):
+        """Determine the path to the kubectl program on the host.
         1) Check the config for a provider_cli in the general section
            remember to add /host prefix
         2) Search /usr/bin:/usr/local/bin
@@ -88,7 +90,12 @@ class KubernetesProvider(Provider):
 
         raise ProviderFailedException("No kubectl found in %s" % ":".join(test_paths))
 
-    def _callK8s(self, path):
+    def _call_k8s(self, path):
+        """Creates resource in manifest at given path by calling k8s CLI
+
+        :arg path: Absolute path to Kubernetes resource manifest
+        :raises: Exception
+        """
         cmd = [self.kubectl, "create", "-f", path, "--namespace=%s" % self.namespace]
 
         if self.dryrun:
@@ -105,18 +112,30 @@ class KubernetesProvider(Provider):
                 printErrorStatus("cmd failed: " + " ".join(cmd))
                 raise
 
-    def prepareOrder(self):
+    def process_k8s_artifacts(self):
+        """Processes Kubernetes manifests files and checks if manifest under
+        process is valid.
+        """
         for artifact in self.artifacts:
             data = None
             with open(os.path.join(self.path, artifact), "r") as fp:
                 logger.debug(os.path.join(self.path, artifact))
                 data = anymarkup.parse(fp)
             if "kind" in data:
-                self.kube_order[data["kind"].lower()] = artifact
+                self.k8s_manifests.append((data["kind"].lower(), artifact))
             else:
                 raise ProviderFailedException("Malformed kube file")
 
-    def _resourceIdentity(self, path):
+    def _resource_identity(self, path):
+        """Finds the Kubernetes resource name / identity from resource manifest
+        and raises if manifest is not supported.
+
+        :arg path: Absolute path to Kubernetes resource manifest
+
+        :return: str -- Resource name / identity
+
+        :raises: ProviderFailedException
+        """
         data = anymarkup.parse_file(path)
         if data["apiVersion"] == "v1":
             return data["metadata"]["name"]
@@ -128,9 +147,14 @@ class KubernetesProvider(Provider):
         else:
             raise ProviderFailedException("Malformed kube file: %s" % path)
 
-    def _resetReplicas(self, path):
-        rname = self._resourceIdentity(path)
-        cmd = [self.kubectl, "resize", "rc", rname, "--replicas=0", "--namespace=%s" %
+    def _scale_replicas(self, path, replicas=0):
+        """Scales replicationController to specified replicas size
+
+        :arg path: Path to replicationController manifest
+        :arg replicas: Replica size to scale to.
+        """
+        rname = self._resource_identity(path)
+        cmd = [self.kubectl, "scale", "rc", rname, "--replicas=0", "--namespace=%s" %
                self.namespace]
 
         if self.dryrun:
@@ -139,28 +163,34 @@ class KubernetesProvider(Provider):
             subprocess.check_call(cmd)
 
     def deploy(self):
+        """Deploys the app by given resource manifests.
+        """
         logger.info("Deploying to Kubernetes")
-        self.prepareOrder()
+        self.process_k8s_artifacts()
 
-        for artifact in self.kube_order:
-            if not self.kube_order[artifact]:
+        for kind, artifact in self.k8s_manifests:
+            if not artifact:
                 continue
 
-            k8s_file = os.path.join(self.path, self.kube_order[artifact])
-            self._callK8s(k8s_file)
+            k8s_file = os.path.join(self.path, artifact)
+            self._call_k8s(k8s_file)
 
     def undeploy(self):
+        """Undeploys the app by given resource manifests.
+        Undeploy operation first scale down the replicas to 0 and then deletes
+        the resource from cluster.
+        """
         logger.info("Undeploying from Kubernetes")
-        self.prepareOrder()
+        self.process_k8s_artifacts()
 
-        for kind, artifact in self.kube_order.iteritems():
-            if not self.kube_order[kind]:
+        for kind, artifact in self.k8s_manifests:
+            if not artifact:
                 continue
 
             path = os.path.join(self.path, artifact)
 
             if kind in ["ReplicationController", "rc", "replicationcontroller"]:
-                self._resetReplicas(path)
+                self._scale_replicas(path, replicas=0)
 
             cmd = [self.kubectl, "delete", "-f", path, "--namespace=%s" % self.namespace]
             if self.dryrun:

--- a/tests/cached_nulecules/gitlab/.workdir/gitlab/artifacts/kubernetes/gitlab-http-service.json
+++ b/tests/cached_nulecules/gitlab/.workdir/gitlab/artifacts/kubernetes/gitlab-http-service.json
@@ -1,0 +1,20 @@
+{
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "name": "gitlab"
+    },
+    "spec":{
+        "ports": [
+            {
+               "targetPort": "gitlab-http",
+               "port": 80,
+               "nodePort": 80
+            }
+        ],
+        "type": "NodePort",
+        "selector": {
+            "name": "gitlab"
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/.workdir/gitlab/artifacts/kubernetes/gitlab-rc.json
+++ b/tests/cached_nulecules/gitlab/.workdir/gitlab/artifacts/kubernetes/gitlab-rc.json
@@ -1,0 +1,59 @@
+{
+    "apiVersion": "v1",
+    "kind": "ReplicationController",
+    "metadata": {
+        "name": "gitlab",
+        "labels": {
+            "name": "gitlab"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "name": "gitlab"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "gitlab"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "gitlab",
+                        "image": "swordphilic/gitlab:latest",
+                        "env": [
+                            {
+                                "name": "DB_USER",
+                                "value": "gitlab"
+                            },
+                            {
+                                "name": "DB_PASS",
+                                "value": "password"
+                            },
+                            {
+                                "name": "DB_NAME",
+                                "value": "gitlab_production"
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "name": "gitlab-http",
+                                "containerPort": 80
+                            },
+                            {
+                                "name": "gitlab-https",
+                                "containerPort": 443
+                            },
+                            {
+                                "name": "gitlab-ssh",
+                                "containerPort": 22
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/.workdir/postgresql/artifacts/kubernetes/postgres-rc.json
+++ b/tests/cached_nulecules/gitlab/.workdir/postgresql/artifacts/kubernetes/postgres-rc.json
@@ -1,0 +1,52 @@
+{
+    "kind": "ReplicationController",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "postgresql",
+        "labels": {
+            "name": "postgresql"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "name": "postgresql"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "postgresql"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "postgresql",
+                        "image": "swordphilic/postgresql:latest",
+                        "ports": [
+                            {
+                                "name": "postgresql-port",
+                                "containerPort": 5432
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "DB_USER",
+                                "value": "gitlab"
+                            },
+                            {
+                                "name": "DB_PASS",
+                                "value": "password"
+                            },
+                            {
+                                "name": "DB_NAME",
+                                "value": "gitlab_production"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+    }
+}

--- a/tests/cached_nulecules/gitlab/.workdir/postgresql/artifacts/kubernetes/postgres-service.json
+++ b/tests/cached_nulecules/gitlab/.workdir/postgresql/artifacts/kubernetes/postgres-service.json
@@ -1,0 +1,18 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "postgresql"
+    },
+    "spec": {
+        "ports": [
+            {
+                "targetPort": "postgresql-port",
+                "port": 5432
+            }
+        ],
+        "selector": {
+            "name": "postgresql"
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/.workdir/redis/artifacts/kubernetes/redis-rc.json
+++ b/tests/cached_nulecules/gitlab/.workdir/redis/artifacts/kubernetes/redis-rc.json
@@ -1,0 +1,37 @@
+{
+    "kind": "ReplicationController",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "redis",
+        "labels": {
+            "name": "redis"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "name": "redis"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "redis"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "redis",
+                        "image": "swordphilic/redis:latest",
+                        "ports": [
+                            {
+                                "name": "redis-port",
+                                "containerPort": 6379
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/.workdir/redis/artifacts/kubernetes/redis-service.json
+++ b/tests/cached_nulecules/gitlab/.workdir/redis/artifacts/kubernetes/redis-service.json
@@ -1,0 +1,16 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "redis"
+    },
+    "spec": {
+        "ports": {
+            "targetPort": "redis-port",
+            "port": 6379
+        },
+        "selector": {
+            "name": "redis"
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/Dockerfile
+++ b/tests/cached_nulecules/gitlab/Dockerfile
@@ -1,0 +1,11 @@
+FROM projectatomic/atomicapp:0.1.3
+
+MAINTAINER Navid Shaikh <nshaikh@redhat.com>
+
+LABEL io.projectatomic.nulecule.specversion 0.0.2
+LABEL io.projectatomic.nulecule.providers "kubernetes"
+
+LABEL Build docker build --rm --tag swordphilic/gitlab-centos7-atomicapp .
+
+ADD /Nulecule /Dockerfile /application-entity/
+ADD /artifacts /application-entity/artifacts

--- a/tests/cached_nulecules/gitlab/Nulecule
+++ b/tests/cached_nulecules/gitlab/Nulecule
@@ -1,0 +1,24 @@
+---
+specversion: 0.0.2
+id: gitlab-atomicapp
+
+metadata:
+  name: Gitlab App
+  appversion: 1.2.0
+  description: Gitlab.
+graph:
+  - name: redis
+    artifacts:
+      kubernetes:
+        - file://artifacts/kubernetes/redis-rc.json
+        - file://artifacts/kubernetes/redis-service.json
+  - name: postgresql
+    artifacts:
+      kubernetes:
+        - file://artifacts/kubernetes/postgres-rc.json
+        - file://artifacts/kubernetes/postgres-service.json
+  - name: gitlab
+    artifacts:
+      kubernetes:
+        - file://artifacts/kubernetes/gitlab-rc.json
+        - file://artifacts/kubernetes/gitlab-http-service.json

--- a/tests/cached_nulecules/gitlab/answers.conf.sample
+++ b/tests/cached_nulecules/gitlab/answers.conf.sample
@@ -1,0 +1,3 @@
+[general]
+namespace = default
+provider = kubernetes

--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/gitlab-http-service.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/gitlab-http-service.json
@@ -1,0 +1,20 @@
+{
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "name": "gitlab"
+    },
+    "spec":{
+        "ports": [
+            {
+               "targetPort": "gitlab-http",
+               "port": 80,
+               "nodePort": 80
+            }
+        ],
+        "type": "NodePort",
+        "selector": {
+            "name": "gitlab"
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/gitlab-rc.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/gitlab-rc.json
@@ -1,0 +1,59 @@
+{
+    "apiVersion": "v1",
+    "kind": "ReplicationController",
+    "metadata": {
+        "name": "gitlab",
+        "labels": {
+            "name": "gitlab"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "name": "gitlab"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "gitlab"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "gitlab",
+                        "image": "swordphilic/gitlab:latest",
+                        "env": [
+                            {
+                                "name": "DB_USER",
+                                "value": "gitlab"
+                            },
+                            {
+                                "name": "DB_PASS",
+                                "value": "password"
+                            },
+                            {
+                                "name": "DB_NAME",
+                                "value": "gitlab_production"
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "name": "gitlab-http",
+                                "containerPort": 80
+                            },
+                            {
+                                "name": "gitlab-https",
+                                "containerPort": 443
+                            },
+                            {
+                                "name": "gitlab-ssh",
+                                "containerPort": 22
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/postgres-rc.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/postgres-rc.json
@@ -1,0 +1,52 @@
+{
+    "kind": "ReplicationController",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "postgresql",
+        "labels": {
+            "name": "postgresql"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "name": "postgresql"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "postgresql"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "postgresql",
+                        "image": "swordphilic/postgresql:latest",
+                        "ports": [
+                            {
+                                "name": "postgresql-port",
+                                "containerPort": 5432
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "DB_USER",
+                                "value": "gitlab"
+                            },
+                            {
+                                "name": "DB_PASS",
+                                "value": "password"
+                            },
+                            {
+                                "name": "DB_NAME",
+                                "value": "gitlab_production"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+    }
+}

--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/postgres-service.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/postgres-service.json
@@ -1,0 +1,18 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "postgresql"
+    },
+    "spec": {
+        "ports": [
+            {
+                "targetPort": "postgresql-port",
+                "port": 5432
+            }
+        ],
+        "selector": {
+            "name": "postgresql"
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/redis-rc.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/redis-rc.json
@@ -1,0 +1,37 @@
+{
+    "kind": "ReplicationController",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "redis",
+        "labels": {
+            "name": "redis"
+        }
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "name": "redis"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "redis"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "redis",
+                        "image": "swordphilic/redis:latest",
+                        "ports": [
+                            {
+                                "name": "redis-port",
+                                "containerPort": 6379
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/redis-service.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/redis-service.json
@@ -1,0 +1,16 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "redis"
+    },
+    "spec": {
+        "ports": {
+            "targetPort": "redis-port",
+            "port": 6379
+        },
+        "selector": {
+            "name": "redis"
+        }
+    }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,3 +142,71 @@ class TestCLISuite(object):
             self.exec_cli(command)
 
         assert exec_info.value.code == 0
+
+    def test_install_with_gitlab_app(self):
+        # prepare the atomicapp command to dry run
+        command = [
+            "main.py",
+            "--verbose",
+            "--dry-run",
+            "install",
+            tests_root + 'cached_nulecules/gitlab/'
+        ]
+
+        # run the command and check if it was successful
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        assert exec_info.value.code == 0
+
+        work_dir = os.path.join(
+            tests_root,
+            "cached_nulecules/gitlab/.workdir")
+
+        assert set(os.listdir(work_dir)) == \
+            set(["gitlab", "postgresql", "redis"])
+
+    def test_run_with_gitlab_app(self):
+        # prepare the atomicapp command to dry run
+        command = [
+            "main.py",
+            "--verbose",
+            "--dry-run",
+            "run",
+            tests_root + 'cached_nulecules/gitlab/'
+        ]
+
+        # run the command and check if it was successful
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        assert exec_info.value.code == 0
+
+        work_dir = os.path.join(
+            tests_root,
+            "cached_nulecules/gitlab/.workdir")
+        assert set(os.listdir(work_dir)) == \
+            set(["gitlab", "postgresql", "redis"])
+
+    def test_stop_with_gitlab_app(self):
+        self.test_run_with_gitlab_app()
+        # prepare the atomicapp command to dry run
+        command = [
+            "main.py",
+            "--verbose",
+            "--dry-run",
+            "stop",
+            tests_root + 'cached_nulecules/gitlab/'
+        ]
+
+        # run the command and check if it was successful
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        assert exec_info.value.code == 0
+
+        work_dir = os.path.join(
+            tests_root,
+            "cached_nulecules/gitlab/.workdir")
+        assert set(os.listdir(work_dir)) == \
+            set(["gitlab", "postgresql", "redis"])


### PR DESCRIPTION
Fixes: https://github.com/projectatomic/atomicapp/issues/212

 - Nulecule multiple resource artifacts defined per kind of resource can now be
 processed without overriding earlier artifacts
 - Modifies the methods names as per <https://www.python.org/dev/peps/pep-0008/#method-names-and-instance-variables>
 - Alters order of imports as per <https://www.python.org/dev/peps/pep-0008/#imports>
 - Adds docstring to methods