### PR TITLE
debian dockerfile support

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,32 @@
+FROM debian:jessie
+
+MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
+
+LABEL io.projectatomic.nulecule.atomicappversion="0.1.3" \
+      RUN="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp" \
+      INSTALL="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity"
+
+WORKDIR /opt/atomicapp
+
+# add all of Atomic App's files to the container image
+ADD atomicapp/ /opt/atomicapp/atomicapp/
+ADD setup.py requirements.txt /opt/atomicapp/
+
+# add jessie-backports for Docker package
+RUN echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list
+
+# lets install pip, and gcc for the native extensions
+# and remove all after use
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends docker.io python-pip python-setuptools gcc && \
+    python setup.py install && \
+    apt-get remove --purge -y python-pip gcc python-setuptools && \
+    apt-get autoremove -y && \
+    apt-get clean -y
+
+WORKDIR /atomicapp
+VOLUME /atomicapp
+
+# the entrypoint
+ENTRYPOINT ["/usr/bin/atomicapp"]

--- a/atomicapp.sh
+++ b/atomicapp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 if [ "$1" == "-h" -o "$1" == "--help" ]; then
     echo "This script let's you to run the atomicapp container as a tool."

--- a/build_run.sh
+++ b/build_run.sh
@@ -4,7 +4,7 @@ WHAT=$1
 
 # TODO sanity check that we got docker >= 1.6
 
-[ -z "${WHAT}" ] && echo "Need to provide a distro you want to build for (fedora|centos|rhel7)" && exit
+[ -z "${WHAT}" ] && echo "Need to provide a distro you want to build for (fedora|centos|rhel7|debian)" && exit
 IMAGE_NAME=atomicapp-${WHAT}
 
 if [ -z "$USERNAME" ]; then


### PR DESCRIPTION
addresses #250 
Added more support for Debian. Using Debian Jessie for atomicapp deployment.

EDIT: to test/run use: 
```
docker build -t projectatomic/debian --file `pwd`/Dockerfile.debian `pwd`
```
