### PR TITLE
Fix gitlab example in tests/cached_nulecules/

### DIFF
--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/gitlab-http-service.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/gitlab-http-service.json
@@ -9,7 +9,7 @@
             {
                "targetPort": "gitlab-http",
                "port": 80,
-               "nodePort": 80
+               "nodePort": 30000
             }
         ],
         "type": "NodePort",

--- a/tests/cached_nulecules/gitlab/artifacts/kubernetes/redis-service.json
+++ b/tests/cached_nulecules/gitlab/artifacts/kubernetes/redis-service.json
@@ -5,10 +5,12 @@
         "name": "redis"
     },
     "spec": {
-        "ports": {
-            "targetPort": "redis-port",
-            "port": 6379
-        },
+        "ports": [
+            {
+                "targetPort": "redis-port",
+                "port": 6379
+            }
+        ],
         "selector": {
             "name": "redis"
         }


### PR DESCRIPTION
There were few fixes needed in the Kubernetes artifacts. This patch fixes them.