### PR TITLE
artifact logic bugfix

### DIFF
--- a/atomicapp/nulecule_base.py
+++ b/atomicapp/nulecule_base.py
@@ -172,7 +172,12 @@ class Nulecule_Base(object):
         return params
 
     def getValues(self, component=GLOBAL_CONF, skip_asking=False):
-        params = self.get(component, not skip_asking)
+        if skip_asking:
+            params = self.get(component, skip_asking)
+            values = self._getComponentValues(params, not skip_asking)
+        else:
+            params = self.get(component, not skip_asking)
+            values = self._getComponentValues(params, skip_asking)
 
         values = self._getComponentValues(params, skip_asking)
         for n, p in values.iteritems():

--- a/tests/units/test_nulecule_base.py
+++ b/tests/units/test_nulecule_base.py
@@ -1,0 +1,24 @@
+import unittest
+from atomicapp.nulecule_base import Nulecule_Base
+
+class TestNuleculeBase(unittest.TestCase):
+
+    def setUp(self):
+        self.nulecule_base = Nulecule_Base(
+            dryrun=True,
+            cli_provider="kubernetes")
+
+    def tearDown(self):
+        pass
+
+    def test_answers_config(self):
+        data = {'general': {'namespace': 'testing', 'provider': 'kubernetes'}}
+        self.nulecule_base.loadAnswers(data)
+        config = self.nulecule_base.getValues()
+        self.assertEqual(config["namespace"], "testing")
+
+    def test_answers_config_with_skip(self):
+        data = {'general': {'namespace': 'testing', 'provider': 'kubernetes'}}
+        self.nulecule_base.loadAnswers(data)
+        config = self.nulecule_base.getValues(skip_asking=True)
+        self.assertEqual(config["namespace"], "testing")


### PR DESCRIPTION
fixes issue #259 

Logic error in nulecule_base when obtaining artifact + answers.conf file for stopping / undeploying a provider.

Namespace + provider variable from answers is not passed thus you cannot obtain the configuration information for undeployment. 