### PR TITLE
Add `providerconfig` option to fix #266

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -47,3 +47,5 @@ DEFAULT_ANSWERS = {
         "namespace": DEFAULT_NAMESPACE
     }
 }
+PROVIDER_CONFIG_KEY="providerconfig"
+DEFAULT_PROVIDER_CONFIG="~/.kube/config"

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -47,5 +47,5 @@ DEFAULT_ANSWERS = {
         "namespace": DEFAULT_NAMESPACE
     }
 }
-PROVIDER_CONFIG_KEY="providerconfig"
-DEFAULT_PROVIDER_CONFIG="~/.kube/config"
+PROVIDER_CONFIG_KEY = "providerconfig"
+DEFAULT_PROVIDER_CONFIG = "~/.kube/config"

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -50,23 +50,14 @@ class OpenShiftProvider(Provider):
                 os.symlink(os.path.join(Utils.getRoot(), "usr/bin/oc"), "/usr/bin/oc")
                 self.cli = "/usr/bin/oc"
 
-        if not self.cli or not os.access(self.cli, os.X_OK):
-            raise ProviderFailedException("Command %s not found" % self.cli)
-        else:
-            logger.debug("Using %s to run OpenShift commands.", self.cli)
+        if not self.dryrun:
+            if not self.cli or not os.access(self.cli, os.X_OK):
+                raise ProviderFailedException("Command %s not found" % self.cli)
+            else:
+                logger.debug("Using %s to run OpenShift commands.", self.cli)
 
-        if "openshiftconfig" in self.config:
-            self.config_file = self.config["openshiftconfig"]
-            if self.container:
-                self.config_file = os.path.join(Utils.getRoot(), self.config_file.lstrip("/"))
-        else:
-            logger.warning("Configuration option 'openshiftconfig' not found")
-
-        if not self.config_file or not os.access(self.config_file, os.R_OK):
-            raise ProviderFailedException(
-                "Cannot access configuration file %s. Try adding "
-                "'openshiftconfig = /path/to/your/.kube/config' in the "
-                "[general] section of the answers.conf file." % self.config_file)
+            # Check if OpenShift config file is accessible
+            self.checkConfigFile()
 
     def _callCli(self, path):
         cmd = [self.cli, "--config=%s" % self.config_file, "create", "-f", path]

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -16,13 +16,16 @@ Atomic App 0.1.3 includes three providers:
 
 All providers assume that you install and run the Atomic App on a host that is part of the backend cluster or runs docker directly. By now we do not support remote deployments.
 
-## Choosing a provider
+## Choosing and configuring a provider
 While deploying an Atomic App you can choose one of the providers by setting it in `answers.conf`:
 
 ```
 [general]
 provider: openshift
+providerconfig: /host/home/foo/.kube/config
 ```
+
+You need to provide Atomic App with access to a configuration file to be able to use Kubernetes and OpenShift providers. By using the `providerconfig` option you will override it's default value (`~/.kube/config`).
 
 Providers may need additional configuration.
 
@@ -77,16 +80,12 @@ This command undeploys the app in Kubernetes cluster in specified namespace. For
 The OpenShift3 Provider will deploy and run an Atomic App on an OpenShift3 instance provided via an OpenShift3 configuration file. An OpenShift3 configuration file is written to a disk provided that you have logged in see [osc login announcement](http://lists.openshift.redhat.com/openshift-archives/users/2015-March/msg00014.html)
 
 
-You need to provide a copy of `.config/openshift/.config` so that the provider may use this configuration to deploy and run the Atomic App.
+You need to provide a path to a copy of `.config/openshift/.config` as `providerconfig` so that the provider may use this configuration to deploy and run the Atomic App.
 
 
 As of 0.1.3 of Atomic App, OpenShift3 templates will only be processed by Atomic App during the run phase. The names of the parameters supplied by the OpenShift3 template file will be replaced by the parameters supplied to Atomic App.
 
 **Configuration values**
 
-Table 1. OpenShift3 default configuration values
-
-Keyword         | Required | Description                                 | Default value
-----------------|----------|---------------------------------------------|--------------
-openshiftconfig |   no     |   path to OpenShift3 configuration file     | none
+There are no configuration values specific to OpenShift provider.
 

--- a/tests/units/test_providers.py
+++ b/tests/units/test_providers.py
@@ -1,0 +1,46 @@
+import unittest
+import mock
+import tempfile
+import os
+import json
+from atomicapp.plugin import Plugin, ProviderFailedException
+from atomicapp.nulecule_base import Nulecule_Base
+
+class TestNuleculeBase(unittest.TestCase):
+    def setUp(self):
+        self.nulecule_base = Nulecule_Base(dryrun = True)
+        self.tmpdir = tempfile.mkdtemp(prefix = "atomicapp-test", dir = "/tmp")
+        self.plugin = Plugin()
+        self.plugin.load_plugins()
+
+    def tearDown(self):
+        pass
+
+    def create_temp_file(self):
+        return tempfile.mktemp(prefix = "test-config", dir = self.tmpdir)
+
+    def prepare_provider(self, data):
+        self.nulecule_base.loadAnswers(data)
+        provider_class = self.plugin.getProvider(self.nulecule_base.provider)
+        config = self.nulecule_base.getValues(skip_asking=True)
+        provider = provider_class(config, self.tmpdir, dryrun = False)
+
+        return provider
+
+    def test_provider_config_exist(self):
+        provider_config_path = self.create_temp_file()
+        with open(provider_config_path, "w") as fp:
+            fp.write("This is config")
+
+        data = {'general': {'namespace': 'testing', 'provider': 'kubernetes', 'providerconfig': '%s' % provider_config_path}}
+        
+        provider = self.prepare_provider(data)
+
+        self.assertEqual(provider.config_file, provider_config_path)
+
+    def test_provider_check_config_fail(self):
+        data = {'general': {'namespace': 'testing', 'provider': 'kubernetes'}}
+
+        provider = self.prepare_provider(data)
+
+        self.assertRaises(ProviderFailedException, provider.checkConfigFile)


### PR DESCRIPTION
There are 2 new methods in `plugin.py`

1. getConfigFile() - which simple looks up the option in `config` dictionary, called automatically by all providers, if there is no such option, default (`~/.kube/config`) is used
2. checkConfigFile() - which checks for the accessibility of the config file, needs to be called explicitly in provider's `init()` function so that providers which do no require configuration (docker) don't fail

