### PR TITLE
Added docker-compose provider #265

### DIFF
--- a/atomicapp/providers/docker_compose.py
+++ b/atomicapp/providers/docker_compose.py
@@ -43,7 +43,7 @@ class DockerComposeProvider(Provider):
             cmd = "docker-compose -f {} up -d".format(artifact_path)
 
             if self.dryrun:
-                logger.info("DRY-RUN: {}".format(cmd))
+                logger.info("DRY-RUN: %s" % cmd)
             else:
                 subprocess.check_call(cmd.split(" "))
 
@@ -58,6 +58,6 @@ class DockerComposeProvider(Provider):
             cmd = "docker-compose -f {} stop".format(artifact_path)
 
             if self.dryrun:
-                logger.info("DRY-RUN: {}".format(cmd))
+                logger.info("DRY-RUN: %s" % cmd)
             else:
                 subprocess.check_call(cmd.split(" "))

--- a/atomicapp/providers/docker_compose.py
+++ b/atomicapp/providers/docker_compose.py
@@ -44,7 +44,7 @@ class DockerComposeProvider(Provider):
             cmd = "docker-compose -f {} up -d".format(artifact_path)
 
             if self.dryrun:
-                logger.info("DRY-RUN: %s" % cmd)
+                logger.info("DRY-RUN: %s", cmd)
             else:
                 subprocess.check_call(cmd.split(" "))
 
@@ -58,7 +58,7 @@ class DockerComposeProvider(Provider):
             cmd = "docker-compose -f {} stop".format(artifact_path)
 
             if self.dryrun:
-                logger.info("DRY-RUN: %s" % cmd)
+                logger.info("DRY-RUN: %s", cmd)
             else:
                 subprocess.check_call(cmd.split(" "))
 
@@ -68,7 +68,7 @@ class DockerComposeProvider(Provider):
                 data = anymarkup.parse(fp)
                 if not data:
                     logger.info(
-                        'Skipping empty compose YAML file: %s' % artifact_path)
+                        'Skipping empty compose YAML file: %s', artifact_path)
                     return True
             except Exception:
                 msg = "Error processing %s artifacts, Error: %s" % (

--- a/atomicapp/providers/docker_compose.py
+++ b/atomicapp/providers/docker_compose.py
@@ -1,0 +1,56 @@
+"""
+ Copyright 2015 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from atomicapp.plugin import Provider, ProviderFailedException
+import os
+import subprocess
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DockerComposeProvider(Provider):
+    key = "docker-compose"
+
+    def init(self):
+        pass
+
+    def deploy(self):
+        for artifact in self.artifacts:
+            artifact_path = os.path.join(self.path, artifact)
+
+            cmd = "docker-compose -f {} up -d".format(artifact_path)
+            logger.info("DRY-RUN: {}".format(cmd))
+
+            if self.dryrun:
+                logger.info("DRY-RUN: {}".format(cmd))
+            else:
+                subprocess.check_call(cmd.split(" "))
+
+    def undeploy(self):
+        for artifact in self.artifacts:
+            artifact_path = os.path.join(self.path, artifact)
+
+            cmd = "docker-compose -f {} stop".format(artifact_path)
+
+            if self.dryrun:
+                logger.info("DRY-RUN: {}".format(cmd))
+            else:
+                subprocess.check_call(cmd.split(" "))

--- a/atomicapp/providers/docker_compose.py
+++ b/atomicapp/providers/docker_compose.py
@@ -17,7 +17,7 @@
  along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
 """
 
-from atomicapp.plugin import Provider, ProviderFailedException
+from atomicapp.plugin import Provider
 import os
 import subprocess
 
@@ -36,8 +36,11 @@ class DockerComposeProvider(Provider):
         for artifact in self.artifacts:
             artifact_path = os.path.join(self.path, artifact)
 
+            if artifact_path.find('noop-compose') >= 0:
+                logger.info('Skipping noop compose YAML file.')
+                continue
+
             cmd = "docker-compose -f {} up -d".format(artifact_path)
-            logger.info("DRY-RUN: {}".format(cmd))
 
             if self.dryrun:
                 logger.info("DRY-RUN: {}".format(cmd))
@@ -47,6 +50,10 @@ class DockerComposeProvider(Provider):
     def undeploy(self):
         for artifact in self.artifacts:
             artifact_path = os.path.join(self.path, artifact)
+
+            if artifact_path.find('noop-compose') >= 0:
+                logger.info('Skipping noop compose YAML file.')
+                continue
 
             cmd = "docker-compose -f {} stop".format(artifact_path)
 

--- a/atomicapp/providers/docker_compose.py
+++ b/atomicapp/providers/docker_compose.py
@@ -70,8 +70,8 @@ class DockerComposeProvider(Provider):
                     logger.info(
                         'Skipping empty compose YAML file: %s', artifact_path)
                     return True
-            except Exception:
+            except Exception as e:
                 msg = "Error processing %s artifacts, Error: %s" % (
-                    artifact_path)
+                    artifact_path, e)
                 printErrorStatus(msg)
                 raise

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -13,6 +13,7 @@ OpenShift and Kubernetes.
 Atomic App includes three providers:
 
   * Docker
+  * Docker Compose
   * Kubernetes
   * OpenShift 3
 
@@ -26,5 +27,6 @@ More documentation for each of the providers can be found in the links
 below:
 
    * [Docker](./providers/docker/overview.md)
+   * [Docker Compose](./providers/docker-compose/overview.md)
    * [Kubernetes](./providers/kubernetes/overview.md)
    * [OpenShift](./providers/openshift/overview.md)

--- a/docs/providers/docker-compose/overview.md
+++ b/docs/providers/docker-compose/overview.md
@@ -1,0 +1,61 @@
+# Docker Compose
+
+### Overview
+
+The Docker Compose provider: ``docker-compose``
+will start a set of docker containers for a multi-tier application as
+specified in a Docker Compose YAML file on the host the Atomic App is
+deployed. Since, a docker compose YAML file will represent
+the entire graph of applications in a Nulecule file, you don't need to run
+docker compose on each application in the Nulecule graph. However, since
+each provider for an application must point to an artifact file, you can
+point to an empty ``artifacts/docker-compose/noop-compose.yaml`` artifact
+file for applications you want to skip running docker compose on.
+
+### Configuration
+
+#### namespace
+
+The psuedo namespace to use when naming docker containers. Docker does not properly support namespacing so this is done by naming containers in a predictable manner with the value of the namespace as part of the name.
+
+The namespace can be changed in the [general] section of the answers.conf file. An example is below:
+
+```
+[general]
+namespace: mynamespace
+```
+
+#### providerconfig
+This communicates directly with the docker daemon on the host. It does not use the i``providerconfig`` option.
+
+
+#### Configuration Value Defaults
+
+Table 1. Docker default configuration values
+
+Keyword  | Required | Description                                           | Default value
+---------|----------|-------------------------------------------------------|--------------
+namespace|   no     |   namespace to use when deploying docker containers   | default\*
+
+\*The naming convention used when deploying is: `NAMESPACE_IMAGENAME_HASHVALUE`
+
+
+### Operations
+
+```
+atomicapp run
+```
+
+This command deploys the set of docker containers for a multi-tier application
+as specified in the ``docker-compose`` artifact file. The deployment uses
+the value of `namespace` option within `answers.conf` and deploys with
+a naming convention. If a previous deployment with the same name is detected,
+it will fail and warn the user.
+
+```
+atomicapp stop
+```
+
+This command undeploys all the containers for the multi-tier application
+in Docker run by Docker ``compose`` during running atomicapp.
+


### PR DESCRIPTION
This implements support for ``docker-compose`` as a provider. This work is not yet ready to merge.

Docker compose YAML file is almost analogous to a Nulecule spec file. We don't need to have different compose artifacts for individual application. In this case, how do we accommodate for docker compose in Nulecule file? It seems that artifact for each application for an enabled provider is a must.