### PR TITLE
fix openshift import warning

### DIFF
--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -18,7 +18,7 @@
 """
 
 from atomicapp.plugin import Provider, ProviderFailedException
-from utils import Utils
+from atomicapp.utils import Utils
 
 from collections import OrderedDict
 import os


### PR DESCRIPTION
```
 atomicapp.status.info.message=Install successful
[WARNING]: can't load module 'openshift.py': ImportError('No module named utils',)
 atomicapp.status.info.message=Artifact file://artifacts/docker/hello-apache-pod_run: OK
```

^^ Fixes the openshift warning you get each time you run.