### PR TITLE
Generate provider config for kubernetes if it does not exist

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -49,4 +49,4 @@ DEFAULT_ANSWERS = {
     }
 }
 PROVIDER_CONFIG_KEY = "providerconfig"
-DEFAULT_PROVIDER_CONFIG = "~/.kube/config"
+DEFAULT_PROVIDER_CONFIG = "provider.config"

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -65,6 +65,9 @@ class Provider(object):
     def deploy(self):
         raise NotImplementedError()
 
+    def generateConfigFile(self):
+        raise NotImplementedError()
+
     def getConfigFile(self):
         """
         Looks up provider configuration file (aka ~/.kube/config) in config passed
@@ -79,10 +82,14 @@ class Provider(object):
 
     def checkConfigFile(self):
         if not self.config_file or not os.access(self.config_file, os.R_OK):
-            raise ProviderFailedException(
-                "Cannot access configuration file %s. Try adding "
-                "'%s = /path/to/your/config.file' in the "
-                "[general] section of the answers.conf file." % (self.config_file, PROVIDER_CONFIG_KEY))
+            try:
+                self.generateConfigFile()
+            except NotImplementedError:
+                raise ProviderFailedException(
+                    "Cannot access configuration file %s. Try adding "
+                    "'%s = /path/to/your/config.file' in the "
+                    "[general] section of the answers.conf file."
+                    % (self.config_file, PROVIDER_CONFIG_KEY))
 
     def undeploy(self):
         logger.warning(

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -87,9 +87,9 @@ class Provider(object):
             except NotImplementedError:
                 raise ProviderFailedException(
                     "Cannot access configuration file %s. Try adding "
-                    "'%s = /path/to/your/config.file' in the "
+                    "'%s = /path/to/your/%s' in the "
                     "[general] section of the answers.conf file."
-                    % (self.config_file, PROVIDER_CONFIG_KEY))
+                    % (self.config_file, PROVIDER_CONFIG_KEY, DEFAULT_PROVIDER_CONFIG))
 
     def undeploy(self):
         logger.warning(

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -108,7 +108,7 @@ class KubernetesProvider(Provider):
             os.makedirs(config_dir)
 
         with open(self.config_file, "w") as fp:
-           fp.write(content)
+            fp.write(content)
 
     def _call(self, cmd):
         """Calls given command

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -25,7 +25,7 @@ provider: openshift
 providerconfig: /host/home/foo/.kube/config
 ```
 
-You need to provide Atomic App with access to a configuration file to be able to use Kubernetes and OpenShift providers. By using the `providerconfig` option you will override it's default value (`~/.kube/config`).
+You need to provide Atomic App with access to a configuration file to be able to use some providers. By using the `providerconfig` option you will override it's default value (`provider.config`).
 
 Providers may need additional configuration.
 
@@ -36,7 +36,9 @@ Providers may need additional configuration.
 The Docker provider will simply start a Docker container on the host the Atomic App is deployed.
 
 
-Atomic App will use the name within namespace and append it with `atomic` and a hash value. If `--name` is provided within the Docker artifacts file, this will be used but the user will be given a warning.
+Atomic App will use the name within namespace and append it with `atomic` and a hash value. If `--name` is provided within the Docker artifacts file, this will be used but the user will be given a warning.a
+
+This provider does not use `providerconfig` option.
 
 **Configuration values**
 
@@ -76,6 +78,8 @@ The Kubernetes Provider supports namespaces, this will deploy an application int
 
 
 The default value of `namespace` is `default` unless otherwise defined in the Kubernetes manifest.
+
+This provider requires configuration file to be able to connect to Kubernetes Master. If the configuration file is not provided, it will try to generate default configuration file.
 
 **Configuration values**
 

--- a/tests/units/test_providers.py
+++ b/tests/units/test_providers.py
@@ -58,3 +58,11 @@ class TestNuleculeBase(unittest.TestCase):
         provider.checkConfigFile()
         with open(path, "r") as fp:
             self.assertEqual(fp.read(), MOCK_CONTENT)
+
+    def test_provider_check_config_fail(self):
+        path = self.create_temp_file()
+        data = {'general': {'namespace': 'testing', 'provider': 'openshift'}}
+
+        provider = self.prepare_provider(data)
+
+        self.assertRaises(ProviderFailedException, provider.checkConfigFile)


### PR DESCRIPTION
There is new unimplemented method in Plugin - `generateConfigFile`.
This method is invoked in case a provider calls `checkConfigFile`
and the file does not exist. If provider does not implement
this method, error about missing configuration file will
be printed out. Config file will be generated and used if the method
is implemented.

Currently, it is implemented only by Kubernetes provider.

Fixes #280