### PR TITLE
fix docker multiple artifact bug

### DIFF
--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -72,6 +72,9 @@ class DockerProvider(Provider):
 
     def deploy(self):
         logger.info("Deploying to provider: Docker")
+        for container in self._get_containers():
+            if re.match("%s_+%s+_+[a-zA-Z0-9]{12}" % (self.default_name, self.namespace), container):
+                raise ProviderFailedException("Namespace with name %s already deployed in Docker" % self.namespace)
 
         for artifact in self.artifacts:
             artifact_path = os.path.join(self.path, artifact)
@@ -85,10 +88,8 @@ class DockerProvider(Provider):
             if '--name' in run_args:
                 logger.info("WARNING: Using --name provided within artifact file.")
             else:
-                for container in self._get_containers():
-                    if re.match("%s_+%s+_+[a-zA-Z0-9]{12}" % (self.default_name, self.namespace), container):
-                        raise ProviderFailedException("Namespace with name %s already deployed in Docker" % self.namespace)
                 run_args.insert(run_args.index('run') + 1, "--name=%s_%s_%s" % (self.default_name, self.namespace, Utils.getUniqueUUID()))
+
             cmd = run_args
             if self.dryrun:
                 logger.info("DRY-RUN: %s", " ".join(cmd))

--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -29,7 +29,7 @@ import pytest
 import atomicapp.cli.main
 
 class TestCli(unittest.TestCase):
-
+    
     def exec_cli(self, command):
         saved_args = sys.argv
         sys.argv = command
@@ -170,6 +170,36 @@ class TestCli(unittest.TestCase):
             "--dry-run",
             "stop",
             self.examples_dir + 'wordpress-centos7-atomicapp/'
+        ]
+
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        assert exec_info.value.code == 0
+  
+    def test_run_k8s_app_multiple_artifacts(self):
+        command = [
+            "main.py",
+            "--verbose",
+            "--dry-run",
+            "run",
+            "--provider=docker",
+            self.examples_dir + 'kubernetes-atomicapp/'
+        ]
+
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        assert exec_info.value.code == 0
+
+    def test_stop_k8s_app_multiple_artifacts(self):
+        command = [
+            "main.py",
+            "--verbose",
+            "--dry-run",
+            "stop",
+            "--provider=docker",
+            self.examples_dir + 'kubernetes-atomicapp/'
         ]
 
         with pytest.raises(SystemExit) as exec_info:

--- a/tests/units/cli/test_examples/kubernetes-atomicapp/Dockerfile
+++ b/tests/units/cli/test_examples/kubernetes-atomicapp/Dockerfile
@@ -1,0 +1,9 @@
+FROM projectatomic/atomicapp:0.1.3
+
+MAINTAINER Jason Brooks <jbrooks@redhat.com>
+
+LABEL io.projectatomic.nulecule.specversion 0.0.2
+LABEL io.projectatomic.nulecule.providers = "docker"
+
+ADD /Nulecule /Dockerfile /answers.conf /application-entity/
+ADD /artifacts /application-entity/artifacts

--- a/tests/units/cli/test_examples/kubernetes-atomicapp/Nulecule
+++ b/tests/units/cli/test_examples/kubernetes-atomicapp/Nulecule
@@ -1,0 +1,15 @@
+---
+specversion: 0.0.2
+id: kubernetes-atomicapp
+
+metadata:
+  name: Kubernetes Atomic App
+  appversion: 0.0.1
+  description: Atomic app for deploying a local, dockerized kubernetes
+graph:
+  - name: kubernetes-atomicapp
+    artifacts:
+      docker:
+        - file://artifacts/docker/kube-etcd_run
+        - file://artifacts/docker/kube-master_run
+        - file://artifacts/docker/kube-svcproxy_run

--- a/tests/units/cli/test_examples/kubernetes-atomicapp/answers.conf
+++ b/tests/units/cli/test_examples/kubernetes-atomicapp/answers.conf
@@ -1,0 +1,4 @@
+[kubernetes-atomicapp]
+[general]
+namespace = kubernetes
+provider = docker

--- a/tests/units/cli/test_examples/kubernetes-atomicapp/artifacts/docker/kube-etcd_run
+++ b/tests/units/cli/test_examples/kubernetes-atomicapp/artifacts/docker/kube-etcd_run
@@ -1,0 +1,1 @@
+docker run --net=host -d gcr.io/google_containers/etcd:2.0.9 /usr/local/bin/etcd --addr=127.0.0.1:4001 --bind-addr=0.0.0.0:4001 --data-dir=/var/etcd/data

--- a/tests/units/cli/test_examples/kubernetes-atomicapp/artifacts/docker/kube-master_run
+++ b/tests/units/cli/test_examples/kubernetes-atomicapp/artifacts/docker/kube-master_run
@@ -1,0 +1,1 @@
+docker run --net=host -d -v /var/run/docker.sock:/var/run/docker.sock gcr.io/google_containers/hyperkube:v0.21.2 /hyperkube kubelet --api_servers=http://localhost:8080 --v=2 --address=0.0.0.0 --enable_server --hostname_override=127.0.0.1 --config=/etc/kubernetes/manifests

--- a/tests/units/cli/test_examples/kubernetes-atomicapp/artifacts/docker/kube-svcproxy_run
+++ b/tests/units/cli/test_examples/kubernetes-atomicapp/artifacts/docker/kube-svcproxy_run
@@ -1,0 +1,1 @@
+docker run -d --net=host --privileged gcr.io/google_containers/hyperkube:v0.21.2 /hyperkube proxy --master=http://127.0.0.1:8080 --v=2

--- a/tests/units/providers/docker_artifact_test/hello-world-one
+++ b/tests/units/providers/docker_artifact_test/hello-world-one
@@ -1,0 +1,1 @@
+docker run -d -p $hostport:80 $image

--- a/tests/units/providers/docker_artifact_test/hello-world-three
+++ b/tests/units/providers/docker_artifact_test/hello-world-three
@@ -1,0 +1,1 @@
+docker run -d -p $hostport:4000 $image

--- a/tests/units/providers/docker_artifact_test/hello-world-two
+++ b/tests/units/providers/docker_artifact_test/hello-world-two
@@ -1,0 +1,1 @@
+docker run -d -p $hostport:8080 $image

--- a/tests/units/providers/test_docker_provider.py
+++ b/tests/units/providers/test_docker_provider.py
@@ -1,0 +1,83 @@
+"""
+ Copyright 2015 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import unittest
+import pytest
+import mock
+import tempfile
+import os
+import json
+from atomicapp.plugin import Plugin, ProviderFailedException
+from atomicapp.nulecule_base import Nulecule_Base
+from atomicapp.providers.docker import DockerProvider
+from atomicapp.constants import DEFAULT_CONTAINER_NAME, DEFAULT_NAMESPACE
+
+def mock_name_get_call(self):
+    return ["atomic_default_e9b9a7bfe8f9"]
+
+class TestDockerProviderBase(unittest.TestCase):
+    
+    # Create a temporary directory for our setup as well as load the required providers
+    def setUp(self):
+        self.nulecule_base = Nulecule_Base(dryrun = True)
+        self.tmpdir = tempfile.mkdtemp(prefix = "atomicapp-test", dir = "/tmp")
+        self.artifact_dir = os.path.dirname(__file__) + '/docker_artifact_test/'
+        self.plugin = Plugin()
+        self.plugin.load_plugins()
+
+    def tearDown(self):
+        pass
+    
+    # Lets prepare the docker provider with pre-loaded configuration
+    def prepare_provider(self, data):
+        self.nulecule_base.loadAnswers(data)
+        provider_class = self.plugin.getProvider(self.nulecule_base.provider)
+        config = self.nulecule_base.getValues(skip_asking=True)
+        provider = provider_class(config, self.tmpdir, dryrun = True)
+        return provider
+
+    # Test deploying multiple artifacts within docker
+    def test_multiple_artifact_load(self):
+        data = {'general': {'namespace': 'test', 'provider': 'docker'}}
+        provider = self.prepare_provider(data)
+        provider.init()
+        provider.artifacts = [
+                self.artifact_dir + 'hello-world-one',
+                self.artifact_dir + 'hello-world-two',
+                self.artifact_dir + 'hello-world-three'
+                ]
+        # Mock the effects of 'docker ps -a'. As if each deployment adds the container to the host
+        mock_container_list = mock.Mock(side_effect = [
+            ["atomic_default_e9b9a7bfe8f9"], 
+            ["atomic_default_e9b9a7bfe8f9", "atomic_test_e9b9a7bfe8f9"],
+            ["atomic_default_e9b9a7bfe8f9", "atomic_test_e9b9a7bfe8f9", "atomic_test_e9b9a7bfe8f9"]
+            ])
+        with mock.patch("docker.DockerProvider._get_containers", mock_container_list):
+            provider.deploy()
+
+   
+    # Patch in a general container list and make sure it fails if there is already a container with the same name 
+    @mock.patch("docker.DockerProvider._get_containers", mock_name_get_call)
+    def test_namespace_name_check(self):
+        data = {'general': {'namespace': 'default', 'provider': 'docker'}}
+        provider = self.prepare_provider(data)
+        provider.init()
+        provider.artifacts = [self.artifact_dir + 'hello-world-one']
+        with pytest.raises(ProviderFailedException):
+            provider.deploy()

--- a/tests/units/providers/test_kubernetes_provider.py
+++ b/tests/units/providers/test_kubernetes_provider.py
@@ -82,7 +82,6 @@ class TestKubernetesProviderBase(unittest.TestCase):
     def test_provider_check_config_fail(self):
         path = self.create_temp_file()
         data = {'general': {'namespace': 'testing', 'provider': 'openshift'}}
-
         provider = self.prepare_provider(data)
 
         self.assertRaises(ProviderFailedException, provider.checkConfigFile)


### PR DESCRIPTION
Fixes #293 

* We shouldn't be checking namespace every single time a docker container is deployed. Moving it before `for artifact in self.artifacts:` is more programatic.
* If there are multiple artifacts, name each one with a newly generated uuid on each name with the same namespace name.
* Adds test for multiple artifacts launch

**Before**:
```bash
2015-09-25 23:38:35,604 - atomicapp.utils - INFO - atomicapp.status.error.message=Namespace with name default already deployed in Docker
2015-09-25 23:38:35,605 - atomicapp.run - ERROR - Namespace with name default already deployed in Docker
Traceback (most recent call last):
  File "/usr/bin/atomicapp", line 9, in <module>
    load_entry_point('atomicapp==0.1.11', 'console_scripts', 'atomicapp')()
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.11-py2.7.egg/atomicapp/cli/main.py", line 238, in main
    cli.run()
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.11-py2.7.egg/atomicapp/cli/main.py", line 214, in run
    args.func(args)
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.11-py2.7.egg/atomicapp/cli/main.py", line 53, in cli_run
    if ae.run() is not None:
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.11-py2.7.egg/atomicapp/run.py", line 239, in run
    self._dispatchGraph()
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.11-py2.7.egg/atomicapp/run.py", line 132, in _dispatchGraph
    self._processComponent(component, graph_item)
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.11-py2.7.egg/atomicapp/run.py", line 225, in _processComponent
    provider.deploy()
  File "/usr/lib/python2.7/site-packages/atomicapp-0.1.11-py2.7.egg/atomicapp/providers/docker.py", line 90, in deploy
    raise ProviderFailedException("Namespace with name %s already deployed in Docker" % self.namespace)
atomicapp.plugin.ProviderFailedException: Namespace with name default already deployed in Docker
```

**After**:
```bash
2015-10-01 04:04:12,693 - atomicapp.run - DEBUG - Templating artifact /home/wikus/kube/artifacts/docker/kube-svcproxy_run
2015-10-01 04:04:12,693 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value k8s
2015-10-01 04:04:12,693 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value docker
2015-10-01 04:04:12,693 - atomicapp.run - DEBUG - Config: {u'namespace': u'k8s', u'provider': u'docker'} 
2015-10-01 04:04:12,693 - atomicapp.run - DEBUG - {u'namespace': u'k8s', u'provider': u'docker'}
2015-10-01 04:04:12,693 - atomicapp.plugin - DEBUG - Writing artifact to /home/wikus/kube/.workdir/kubernetes-atomicapp/artifacts/docker/kube-svcproxy_run
2015-10-01 04:04:12,693 - docker - DEBUG - Given config: {u'namespace': u'k8s', u'provider': u'docker'}
2015-10-01 04:04:12,693 - docker - DEBUG - Namespace: k8s
2015-10-01 04:04:12,708 - docker - INFO - Deploying to provider: Docker
d53f6db2ed87c6bbc04b3e7aa493b266e3f3197cdf907c4a7c142d4e7786e23c
eb8bd452edec21a92f5b91602c9a034a51a420c52c8514dd3f471da7768f0d2c
b4abc2a2c50c66978fc507939c24aa66183fa8660eab319299b928d167bb6d94
```

