### PR TITLE
Added Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+all:
+	python -m pytest -vv
+
+install:
+	python setup.py install .
+
+test:
+	python -m pytest -vv
+
+image:
+	docker build -t $(tag) .
+
+syntax-check:
+	flake8 atomicapp


### PR DESCRIPTION
Added Makefile, creates some sweet aliases. Satisfies the developer OCD.

Makes everything a little bit easier for local dev / install and for future installations / testing. More aliases can be added here. HINT HINT: `make dev` to Vagrant possibly? :)

```
COMMAND
ALIAS
```

```
make 
(default) python -m pytest -vv
```

````
make install
python setup.py install .
```

```
make test
python -m pytest -vv
```

```
make tag=atomicapp image
docker build -t atomicapp image
```

```
make syntax-check
flake8 atomicapp
```