### PR TITLE
add new method find_binary to find executable

### DIFF
--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -18,7 +18,7 @@
 """
 
 from atomicapp.plugin import Provider, ProviderFailedException
-from atomicapp.utils import Utils
+from atomicapp.utils import Utils, find_binary
 
 from collections import OrderedDict
 import os
@@ -44,7 +44,7 @@ class OpenShiftProvider(Provider):
             host_path = []
             for path in os.environ.get("PATH").split(":"):
                 host_path.append(os.path.join(Utils.getRoot(), path.lstrip("/")))
-            self.cli = find_executable(self.cli_str, path=":".join(host_path))
+            self.cli = find_binary(self.cli_str, path=":".join(host_path))
             if not self.cli:
                 # if run as non-root we need a symlink in the container
                 os.symlink(os.path.join(Utils.getRoot(), "usr/bin/oc"), "/usr/bin/oc")

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 import os
+import sys
 import tempfile
 import re
 import collections
@@ -49,6 +50,31 @@ def printErrorStatus(message):
 
 def printAnswerFile(message):
     logger.info("atomicapp.status.answer.message=" + str(message))
+
+
+def find_binary(executable, path=None):
+    """Tries to find 'executable' in the directories listed in 'path'.
+
+    A string listing directories separated by 'os.pathsep'; defaults to
+    os.environ['PATH'].  Returns the complete filename or None if not found.
+    """
+    if path is None:
+        path = os.environ['PATH']
+
+    paths = path.split(os.pathsep)
+    base, ext = os.path.splitext(executable)
+
+    if (sys.platform == 'win32' or os.name == 'os2') and (ext != '.exe'):
+        executable = executable + '.exe'
+
+    if not os.path.isfile(executable):
+        for p in paths:
+            f = os.path.join(p, executable)
+            if os.path.isfile(f) or os.path.islink(f):
+                return f
+        return None
+    else:
+        return executable
 
 
 class Utils(object):


### PR DESCRIPTION
I had to add a new method to find /host/bin/oc file on openshift provider
the existing method did failed if the file is a symbolic link