### PR TITLE
Fixes grabbing general config namespace through provider

### DIFF
--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -36,8 +36,8 @@ class DockerProvider(Provider):
         self.default_name = DEFAULT_CONTAINER_NAME
 
         logger.debug("Given config: %s", self.config)
-        if self.config.get("namespace"):
-            self.namespace = self.config.get("namespace")
+        if self.config["general"]["namespace"]:
+            self.namespace = self.config["general"]["namespace"]
         logger.debug("Namespace: %s", self.namespace)
 
         if self.dryrun:

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -45,10 +45,10 @@ class KubernetesProvider(Provider):
         self.k8s_manifests = []
 
         logger.debug("Given config: %s", self.config)
-        if self.config.get("namespace"):
-            self.namespace = self.config.get("namespace")
+        if self.config["general"]["namespace"]:
+            self.namespace = self.config["general"]["namespace"]
+        logger.debug("Namespace: %s", self.namespace)
 
-        logger.info("Using namespace %s", self.namespace)
         if self.container:
             self.kubectl = self._find_kubectl(Utils.getRoot())
             kube_conf_path = "/etc/kubernetes"


### PR DESCRIPTION
Fixes #331 since the __entire__ config will be passed to each provider now, not just __general__. Thus you can now grab namespace correctly.