### PR TITLE
Add openshift LABELs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM centos:centos7
 MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
+      io.openshift.generate.job=true \
+      io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
       RUN="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp" \
       STOP="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp" \
       INSTALL="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity"

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -3,6 +3,8 @@ FROM fedora:22
 MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
+      io.openshift.generate.job=true \
+      io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
       RUN="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp" \
       STOP="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp" \
       INSTALL="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity"

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -2,7 +2,9 @@ FROM rhel7
 
 MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
-LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \ 
+LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
+      io.openshift.generate.job=true \
+      io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
       RUN="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp" \
       STOP="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp" \
       INSTALL="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity"

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -121,3 +121,13 @@ As of 0.1.11 of Atomic App, OpenShift3 templates will only be processed by Atomi
 **Configuration values**
 
 There are no configuration values specific to OpenShift provider.
+
+**LABELs**
+
+There are two required labels for OpenShift to run an Atomic App.
+
+1. `io.openshift.generate.job=true`
+  * identify the image as an executable job
+  * run the container to allow the image to determine what OpenShift objects are created.
+1. `io.openshift.generate.token.as=env:TOKEN_ENV_VAR`
+  * run the container with user token so `oc` commands can be run on behalf of the user from within the container pod.


### PR DESCRIPTION
In order for the OpenShift provider to natively
support atomicapp we need to pass in a flag that
identifies the image as an openshift self-executing
job. We also have to instruct OpenShift to pass
in user auth token so we can run oc as that user.

cc @smarterclayton to confirm LABEL correct key=value