### PR TITLE
[Do Not Merge] Add oc client to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ RUN echo -e "[epel]\nname=epel\nenabled=1\nbaseurl=https://dl.fedoraproject.org/
 RUN yum install -y --setopt=tsflags=nodocs python-pip python-setuptools docker gcc && \
     python setup.py install && \
     yum remove -y gcc cpp glibc-devel glibc-headers kernel-headers libmpc mpfr python-pip && \
-    yum clean all
+    yum clean all && \
+    curl -L https://github.com/openshift/origin/releases/download/v1.0.2/openshift-origin-v1.0.2-325c7b7-linux-amd64.tar.gz | tar -zx && \
+    mv oc /usr/local/bin && \
+    rm oadm && \
+    rm openshift
 
 WORKDIR /atomicapp
 VOLUME /atomicapp

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -20,7 +20,11 @@ ADD setup.py requirements.txt /opt/atomicapp/
 RUN dnf install -y --setopt=tsflags=nodocs python-pip python-setuptools docker gcc && \
     python setup.py install && \
     dnf remove -y gcc cpp glibc-devel glibc-headers kernel-headers libmpc mpfr python-pip && \
-    dnf clean all
+    dnf clean all && \
+    curl -L https://github.com/openshift/origin/releases/download/v1.0.2/openshift-origin-v1.0.2-325c7b7-linux-amd64.tar.gz | tar -zx && \
+    mv oc /usr/local/bin && \
+    rm oadm && \
+    rm openshift
 
 WORKDIR /atomicapp
 VOLUME /atomicapp

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -20,7 +20,11 @@ RUN yum install -y yum-utils --setopt=tsflags=nodocs && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable epel && \
     yum install -y --setopt=tsflags=nodocs python-pip docker && \
-    yum clean all
+    yum clean all && \
+    curl -L https://github.com/openshift/origin/releases/download/v1.0.2/openshift-origin-v1.0.2-325c7b7-linux-amd64.tar.gz | tar -zx && \
+    mv oc /usr/local/bin && \
+    rm oadm && \
+    rm openshift
 
 WORKDIR /opt/atomicapp
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -131,3 +131,7 @@ There are two required labels for OpenShift to run an Atomic App.
   * run the container to allow the image to determine what OpenShift objects are created.
 1. `io.openshift.generate.token.as=env:TOKEN_ENV_VAR`
   * run the container with user token so `oc` commands can be run on behalf of the user from within the container pod.
+
+**Client**
+
+When OpenShift runs an Atomic App the `oc` client must be available to the pod that is run. Currently the `oc` client binary is part of the Atomic App base image and the user token is passed into the container pod.


### PR DESCRIPTION
The OpenShift oc client will soon run atomicapp
natively. However the current design requires
the oc CLI client be inside the atomicapp image.
The package is 93M. This is considered a temporary
workaround until another design is proposed.