### PR TITLE
Removes provider config file generation. Fixes #347

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -51,4 +51,3 @@ DEFAULT_ANSWERS = {
     }
 }
 PROVIDER_CONFIG_KEY = "providerconfig"
-DEFAULT_PROVIDER_CONFIG = "provider.config"

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -65,9 +65,6 @@ class Provider(object):
     def deploy(self):
         raise NotImplementedError()
 
-    def generateConfigFile(self):
-        raise NotImplementedError()
-
     def getConfigFile(self):
         """
         Looks up provider configuration file (aka ~/.kube/config) in config passed
@@ -82,14 +79,11 @@ class Provider(object):
 
     def checkConfigFile(self):
         if not self.config_file or not os.access(self.config_file, os.R_OK):
-            try:
-                self.generateConfigFile()
-            except NotImplementedError:
-                raise ProviderFailedException(
-                    "Cannot access configuration file %s. Try adding "
-                    "'%s = /path/to/your/%s' in the "
-                    "[general] section of the answers.conf file."
-                    % (self.config_file, PROVIDER_CONFIG_KEY, DEFAULT_PROVIDER_CONFIG))
+            raise ProviderFailedException(
+                "Cannot access configuration file %s. Try adding "
+                "'%s = /path/to/your/%s' in the "
+                "[general] section of the answers.conf file."
+                % (self.config_file, PROVIDER_CONFIG_KEY, DEFAULT_PROVIDER_CONFIG))
 
     def undeploy(self):
         logger.warning(

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -26,7 +26,7 @@ import imp
 
 import logging
 from utils import Utils
-from constants import HOST_DIR, PROVIDER_CONFIG_KEY, DEFAULT_PROVIDER_CONFIG
+from constants import HOST_DIR, PROVIDER_CONFIG_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class Provider(object):
         if Utils.getRoot() == HOST_DIR:
             self.container = True
 
-        self.config_file = DEFAULT_PROVIDER_CONFIG
+        self.config_file = None
         self.getConfigFile()
 
     def init(self):
@@ -78,12 +78,15 @@ class Provider(object):
             logger.warning("Configuration option '%s' not found" % PROVIDER_CONFIG_KEY)
 
     def checkConfigFile(self):
-        if not self.config_file or not os.access(self.config_file, os.R_OK):
+        if not self.config_file:
+            raise ProviderFailedException(
+                "No provider config file specified!")
+        elif not os.access(self.config_file, os.R_OK):
             raise ProviderFailedException(
                 "Cannot access configuration file %s. Try adding "
-                "'%s = /path/to/your/%s' in the "
+                "'%s = /path/to/your/config_file' in the "
                 "[general] section of the answers.conf file."
-                % (self.config_file, PROVIDER_CONFIG_KEY, DEFAULT_PROVIDER_CONFIG))
+                % (self.config_file, PROVIDER_CONFIG_KEY))
 
     def undeploy(self):
         logger.warning(

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -95,21 +95,6 @@ class KubernetesProvider(Provider):
 
         raise ProviderFailedException("No kubectl found in %s" % ":".join(test_paths))
 
-    def generateConfigFile(self):
-        """Generates configuration file for Kubernetes by calling
-        kubectl config view and saving the output
-        """
-
-        cmd = [self.kubectl, "config", "view"]
-
-        content = self._call(cmd)
-        config_dir = os.path.dirname(self.config_file)
-        if config_dir and not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        with open(self.config_file, "w") as fp:
-            fp.write(content)
-
     def _call(self, cmd):
         """Calls given command
 

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -56,7 +56,7 @@ class OpenShiftProvider(Provider):
             else:
                 logger.debug("Using %s to run OpenShift commands.", self.cli)
 
-            # Check if OpenShift config file is accessible
+            # Check if the required OpenShift config file is accessible.
             self.checkConfigFile()
 
     def _callCli(self, path):

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -19,15 +19,31 @@ All providers assume that you install and run the Atomic App on a host that is p
 ## Choosing and configuring a provider
 While deploying an Atomic App you can choose one of the providers by setting it in `answers.conf`:
 
+### OpenShift
+
+For OpenShift a configuration file is required. You need to specify
+something like the following in your `answers.conf` file:
+
 ```
 [general]
 provider: openshift
 providerconfig: /host/home/foo/.kube/config
 ```
 
-You need to provide Atomic App with access to a configuration file to be able to use some providers. By using the `providerconfig` option you will override it's default value (`provider.config`).
+This specifies to Atomic App where to access the configuration file
+by using the `providerconfig` option.
 
-Providers may need additional configuration.
+### Kubernetes
+
+For Kubernetes the configuration file is optional, but you may find
+that you need it for your setup. If you need it, then you can specify
+the file in the same way that was done in the openshift example above:
+
+```
+[general]
+provider: kubernetes
+providerconfig: /host/home/foo/.kube/config
+```
 
 ### Docker
 

--- a/tests/units/providers/test_kubernetes_provider.py
+++ b/tests/units/providers/test_kubernetes_provider.py
@@ -68,19 +68,6 @@ class TestKubernetesProviderBase(unittest.TestCase):
         provider.checkConfigFile()
         with open(provider_config_path, "r") as fp:
             self.assertEqual(fp.read(), mock_content)
-
-    # Test that atomicapp generates the configuration file correctly
-    @mock.patch("atomicapp.providers.kubernetes.KubernetesProvider._call", mock_provider_call)
-    def test_provider_check_config_generation(self):
-        path = self.create_temp_file()
-        data = {'namespace': 'testing', 'provider': 'kubernetes', 'providerconfig': path}
-
-        provider = self.prepare_provider(data)
-
-        provider.checkConfigFile()
-        with open(path, "r") as fp:
-            self.assertEqual(fp.read(), MOCK_CONTENT)
-
     # If we do not provide a configuration file: fail
     def test_provider_check_config_fail(self):
         path = self.create_temp_file()

--- a/tests/units/providers/test_kubernetes_provider.py
+++ b/tests/units/providers/test_kubernetes_provider.py
@@ -65,13 +65,13 @@ class TestKubernetesProviderBase(unittest.TestCase):
         provider = self.prepare_provider(data)
 
         self.assertEqual(provider.config_file, provider_config_path)
-        provider.checkConfigFile()
+        provider.checkConfigFile()  # should exist since we just created it
         with open(provider_config_path, "r") as fp:
             self.assertEqual(fp.read(), mock_content)
-    # If we do not provide a configuration file: fail
+
+    # If we call checkConfigFile but do not provide a configuration file: fail
     def test_provider_check_config_fail(self):
         path = self.create_temp_file()
         data = {'namespace': 'testing', 'provider': 'openshift'}
         provider = self.prepare_provider(data)
-        provider.checkConfigFile()
         self.assertRaises(ProviderFailedException, provider.checkConfigFile)


### PR DESCRIPTION
We no longer need to generate a config file because kubernetes no
longer fails if one isn't provided. Considering that, we will stop
generating it as it is error prone and keeping up with file is
problematic.