### PR TITLE
Let DockerHandler.extract() check id of existing app. Fixes #136

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -77,7 +77,7 @@ class Nulecule(NuleculeBase):
         logger.info('Unpacking image: %s to %s' % (image, dest))
         docker_handler = DockerHandler(dryrun=dryrun)
         docker_handler.pull(image)
-        docker_handler.extract(image, APP_ENT_PATH, dest)
+        docker_handler.extract(image, APP_ENT_PATH, dest, update)
         return cls.load_from_path(
             dest, config=config, namespace=namespace, nodeps=nodeps,
             dryrun=dryrun, update=update)

--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -79,27 +79,18 @@ class NuleculeManager(object):
         Returns:
             A Nulecule instance.
         """
-        app_exists = os.path.exists(self.main_file)
         logger.debug('Request to unpack to %s to %s' %
                      (self.image, self.app_path))
-        # Unpack/Update/Load the app depending on the current state
-        if app_exists:
-            logger.debug('Nulecule app found at %s.' % self.main_file)
-            if update:
-                logger.debug('Update requested. Unpacking to %s.'
-                             % self.app_path)
-                return Nulecule.unpack(
-                    self.image, self.app_path, config=config,
-                    nodeps=nodeps, dryrun=dryrun, update=update)
-            else:
-                logger.debug('Loading nulecule from %s.' % self.main_file)
-                return Nulecule.load_from_path(
-                    self.app_path, dryrun=dryrun, config=config)
-        else:
-            logger.debug('No app found at %s. Unpacking...' % self.main_file)
+
+        # If the user provided an image then unpack it and return the
+        # resulting Nulecule. Else, load from existing path
+        if self.image:
             return Nulecule.unpack(
                 self.image, self.app_path, config=config,
                 nodeps=nodeps, dryrun=dryrun, update=update)
+        else:
+            return Nulecule.load_from_path(
+                self.app_path, dryrun=dryrun, config=config)
 
     def install(self, answers, nodeps=False, update=False, dryrun=False,
                 answers_format=ANSWERS_FILE_SAMPLE_FORMAT, **kwargs):


### PR DESCRIPTION
In the past it has been possible to unpack/fetch nulecule contents
on top of nulecule contents of separate applications. With this commit
the extraction will stop if the existing app is a different application
than the one requested. This can fix issues like [1].

[1] - https://github.com/projectatomic/atomicapp/issues/136