### PR TITLE
Fixes broken builds bc of lockfile dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 anymarkup>=0.4.1
-lockfile
+lockfile==0.10.2


### PR DESCRIPTION
The new version of lockfile in pypi requires pip itself which we
remove in the Dockerfile. Let's use the older version for now.
See [1] for a more complete explanation.

[1] - https://www.redhat.com/archives/container-tools/2015-October/msg00102.html