### PR TITLE
 Support artifact directory path in NuleculeComponent.

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -362,7 +362,7 @@ class NuleculeComponent(NuleculeBase):
                 path = Utils.sanitizePath(artifact)
                 path = os.path.join(self.basepath, path) \
                     if path[0] != '/' else path
-                artifact_paths.append(path)
+                artifact_paths.extend(self._get_artifact_paths_for_path(path))
             elif isinstance(artifact, dict) and artifact.get('inherit') and \
                     isinstance(artifact.get('inherit'), list):
                 for inherited_provider_key in artifact.get('inherit'):
@@ -403,3 +403,24 @@ class NuleculeComponent(NuleculeBase):
             self.basepath + ('' if self.basepath.endswith('/') else '/'),
             1)[1]
         return render_path
+
+    def _get_artifact_paths_for_path(self, path):
+        """
+        Get artifact paths for a local filesystem path.
+
+        Args:
+            path (str): Local path
+
+        Returns:
+            list: A list of artifact paths
+        """
+        artifact_paths = []
+        if os.path.isfile(path):
+            artifact_paths.append(path)
+        elif os.path.isdir(path):
+            for dir_child in os.listdir(path):
+                dir_child_path = os.path.join(path, dir_child)
+                if dir_child.startswith('.') or os.path.isdir(dir_child_path):
+                    continue
+                artifact_paths.append(dir_child_path)
+        return artifact_paths

--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -406,7 +406,10 @@ class NuleculeComponent(NuleculeBase):
 
     def _get_artifact_paths_for_path(self, path):
         """
-        Get artifact paths for a local filesystem path.
+        Get artifact paths for a local filesystem path. We support path to
+        an artifact file or a directory containing artifact files as its
+        immediate children, i.e., we do not deal with nested artifact
+        directories at this moment.
 
         Args:
             path (str): Local path

--- a/docs/file_handling.md
+++ b/docs/file_handling.md
@@ -11,3 +11,8 @@ Image developers may run the root container and point to a Nulecule directory on
 * `/tmp/<atomicapp_name>`: Host directory for temporary Nulecule files. May be overriden.
 * `/tmp/<atomicapp_name>/.workdir`: Host directory for artifact template files with variable substitution.
 
+## Artifact path
+
+Local path to an artifact file or a directory containing artifact files as its
+immediate children.
+

--- a/tests/units/nulecule/test_nulecule_component.py
+++ b/tests/units/nulecule/test_nulecule_component.py
@@ -1,0 +1,32 @@
+import mock
+import unittest
+from atomicapp.nulecule.base import NuleculeComponent
+
+
+class TestNuleculeComponentLoadArtifactPathsForPath(unittest.TestCase):
+
+    @mock.patch('atomicapp.nulecule.base.os.path.isfile')
+    def test_file_path(self, mock_os_path_isfile):
+        nc = NuleculeComponent('some-name', 'some/path')
+        mock_os_path_isfile.return_value = True
+        self.assertEqual(
+            nc._get_artifact_paths_for_path('some/path/to/file'),
+            ['some/path/to/file'])
+
+    @mock.patch('atomicapp.nulecule.base.os.listdir')
+    @mock.patch('atomicapp.nulecule.base.os.path.isdir')
+    @mock.patch('atomicapp.nulecule.base.os.path.isfile')
+    def test_dir_path(self, mock_os_path_isfile, mock_os_path_isdir,
+                      mock_os_listdir):
+        nc = NuleculeComponent('some-name', 'some/path')
+        mock_os_path_isfile.return_value = False
+        mock_os_path_isdir.side_effect = lambda path: True if path.endswith('dir') else False
+        mock_os_listdir.return_value = [
+            '.foo',
+            'some-dir',
+            'file1',
+            'file2'
+        ]
+        self.assertEqual(
+            nc._get_artifact_paths_for_path('artifacts-dir'),
+            ['artifacts-dir/file1', 'artifacts-dir/file2'])


### PR DESCRIPTION
Fixes #143 

This adds support for handling directory paths in artifacts list in a Nulecule ``graph``. It does actually check if the pathname endswith '/' or not to check if the path is a directory, rather, it uses ``os.path.isdir`` to check if the path is a directory or not.