### PR TITLE
Enables running atomicapp from within a container again.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM centos:centos7
 MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
-      RUN="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3} /atomicapp" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3} /atomicapp" \
-      INSTALL="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run  --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} --destination /atomicapp /application-entity"
+      RUN="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} stop \${OPT3}" \
+      INSTALL="docker run -it --rm \${OPT1} --privileged -v `pwd`:/atomicapp -v /run:/run -v /:/host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} -v \${OPT2} install \${OPT3} \${IMAGE}"
 
 WORKDIR /opt/atomicapp
 

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -27,10 +27,12 @@ from lockfile import LockFile
 from lockfile import AlreadyLocked
 
 from atomicapp import set_logging
-from atomicapp.constants import \
-    ANSWERS_FILE, __ATOMICAPPVERSION__, \
-    __NULECULESPECVERSION__, ANSWERS_FILE_SAMPLE_FORMAT, \
-    LOCK_FILE
+from atomicapp.constants import (__ATOMICAPPVERSION__,
+                                 __NULECULESPECVERSION__,
+                                 ANSWERS_FILE,
+                                 ANSWERS_FILE_SAMPLE_FORMAT,
+                                 HOST_DIR,
+                                 LOCK_FILE)
 from atomicapp.nulecule import NuleculeManager
 from atomicapp.nulecule.exceptions import NuleculeException
 from atomicapp.utils import Utils
@@ -38,9 +40,9 @@ from atomicapp.utils import Utils
 logger = logging.getLogger(__name__)
 
 
-def print_user_msg(app_path):
-    if app_path.startswith('/host'):
-        app_path = app_path[5:]
+def print_app_location(app_path):
+    if app_path.startswith(HOST_DIR):
+        app_path = app_path[len(HOST_DIR):]
     print("\nYour application resides in %s" % app_path)
     print("Please use this directory for managing your application\n")
 
@@ -51,7 +53,7 @@ def cli_install(args):
         nm = NuleculeManager(app_spec=argdict['app_spec'],
                              destination=argdict['destination'])
         nm.install(**argdict)
-        print_user_msg(nm.app_path)
+        print_app_location(nm.app_path)
         sys.exit(0)
     except NuleculeException as e:
         logger.error(e)
@@ -67,7 +69,7 @@ def cli_run(args):
         nm = NuleculeManager(app_spec=argdict['app_spec'],
                              destination=argdict['destination'])
         nm.run(**argdict)
-        print_user_msg(nm.app_path)
+        print_app_location(nm.app_path)
         sys.exit(0)
     except NuleculeException as e:
         logger.error(e)

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -37,10 +37,12 @@ from atomicapp.utils import Utils
 
 logger = logging.getLogger(__name__)
 
-APP_MESSAGE = """
-Your application resides in %s
-Please use this directory for managing your application
-"""
+
+def print_user_msg(app_path):
+    if app_path.startswith('/host'):
+        app_path = app_path[5:]
+    print("\nYour application resides in %s" % app_path)
+    print("Please use this directory for managing your application\n")
 
 
 def cli_install(args):
@@ -49,7 +51,7 @@ def cli_install(args):
         nm = NuleculeManager(app_spec=argdict['app_spec'],
                              destination=argdict['destination'])
         nm.install(**argdict)
-        print(APP_MESSAGE % nm.app_path)  # msg for users
+        print_user_msg(nm.app_path)
         sys.exit(0)
     except NuleculeException as e:
         logger.error(e)
@@ -65,7 +67,7 @@ def cli_run(args):
         nm = NuleculeManager(app_spec=argdict['app_spec'],
                              destination=argdict['destination'])
         nm.run(**argdict)
-        print(APP_MESSAGE % nm.app_path)  # msg for users
+        print_user_msg(nm.app_path)
         sys.exit(0)
     except NuleculeException as e:
         logger.error(e)

--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -41,9 +41,11 @@ class NuleculeManager(object):
 
         # Adjust app_spec and destination paths if absolute.
         if os.path.isabs(app_spec):
-            app_spec = os.path.join(Utils.getRoot(), app_spec[1:])
+            app_spec = os.path.join(Utils.getRoot(),
+                                    app_spec.lstrip('/'))
         if destination and os.path.isabs(destination):
-                destination = os.path.join(Utils.getRoot(), destination[1:])
+                destination = os.path.join(Utils.getRoot(),
+                                           destination.lstrip('/'))
 
         # Determine if the user passed us an image or a path to an app
         if not os.path.exists(app_spec):

--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -10,7 +10,6 @@ from atomicapp.constants import (GLOBAL_CONF,
                                  ANSWERS_FILE,
                                  ANSWERS_FILE_SAMPLE,
                                  ANSWERS_RUNTIME_FILE,
-                                 CACHE_DIR,
                                  DEFAULT_NAMESPACE,
                                  DEFAULT_PROVIDER,
                                  MAIN_FILE)
@@ -40,25 +39,32 @@ class NuleculeManager(object):
         self.app_path = None  # The path where the app resides or will reside
         self.image = None     # The container image to pull the app from
 
-        # Doesn't make sense to provide a local path and a destination
-        if os.path.exists(app_spec) and destination:
+        # Adjust app_spec and destination paths if absolute.
+        if os.path.isabs(app_spec):
+            app_spec = os.path.join(Utils.getRoot(), app_spec[1:])
+        if destination and os.path.isabs(destination):
+                destination = os.path.join(Utils.getRoot(), destination[1:])
+
+        # Determine if the user passed us an image or a path to an app
+        if not os.path.exists(app_spec):
+            self.image = app_spec
+        else:
+            self.app_path = app_spec
+
+        # Doesn't make sense to provide an app path and destination
+        if self.app_path and destination:
             raise NuleculeException(
                 "You can't provide a local path and destination.")
 
-        # Translate the app_spec: a few options:
-        #   - user provided local path to unpacked app
-        #   - user provided container image name (will set app_path
-        #     based on provided destination)
-        if os.path.exists(app_spec):
-            self.app_path = app_spec
-        else:
-            self.image = app_spec
+        # If the user provided an image, make sure we have a destination
+        if self.image:
             if destination:
                 self.app_path = destination
             else:
-                tmpname = "%s-%s" % (Utils.sanitizeName(self.image),
-                                     Utils.getUniqueUUID())
-                self.app_path = os.path.join(CACHE_DIR, tmpname)
+                self.app_path = Utils.getNewAppCacheDir(self.image)
+
+        logger.debug("NuleculeManager init app_path: %s", self.app_path)
+        logger.debug("NuleculeManager init    image: %s", self.image)
 
         # Set where the main nulecule file should be
         self.main_file = os.path.join(self.app_path, MAIN_FILE)

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -136,7 +136,7 @@ class Utils(object):
         """
         path = os.path.join(
             Utils.getRoot(),
-            CACHE_DIR[1:],  # Rip leading / off
+            CACHE_DIR.lstrip('/'),  # Rip leading '/' off
             "%s-%s" % (Utils.sanitizeName(image), Utils.getUniqueUUID()))
         return path
 

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function
 import copy
-import distutils
+import distutils.dir_util
 import os
 import sys
 import tempfile
@@ -31,8 +31,13 @@ from distutils.spawn import find_executable
 
 import logging
 
-from constants import (APP_ENT_PATH, EXTERNAL_APP_DIR, WORKDIR, HOST_DIR,
-                       ANSWERS_FILE, DEFAULT_ANSWERS)
+from constants import (ANSWERS_FILE,
+                       APP_ENT_PATH,
+                       CACHE_DIR,
+                       DEFAULT_ANSWERS,
+                       EXTERNAL_APP_DIR,
+                       HOST_DIR,
+                       WORKDIR)
 
 __all__ = ('Utils')
 
@@ -117,6 +122,23 @@ class Utils(object):
     @staticmethod
     def sanitizeName(app):
         return app.replace("/", "-")
+
+    @staticmethod
+    def getNewAppCacheDir(image):
+        """
+        Get a new unique dir under CACHE_DIR based on the image name
+
+        Args:
+            image (str): The name of the image the app is in
+
+        Returns:
+            path (str): The path to the unique directory
+        """
+        path = os.path.join(
+            Utils.getRoot(),
+            CACHE_DIR[1:],  # Rip leading / off
+            "%s-%s" % (Utils.sanitizeName(image), Utils.getUniqueUUID()))
+        return path
 
     def getExternalAppDir(self, component):
         return os.path.join(
@@ -240,8 +262,21 @@ class Utils(object):
         return cli
 
     @staticmethod
-    def getRoot():
+    def inContainer():
+        """
+        Determine if we are running inside a container or not.
+
+        Returns:
+            (bool): True == we are in a container
+        """
         if os.path.isdir(HOST_DIR):
+            return True
+        else:
+            return False
+
+    @staticmethod
+    def getRoot():
+        if Utils.inContainer():
             return HOST_DIR
         else:
             return "/"
@@ -287,4 +322,4 @@ class Utils(object):
     @staticmethod
     def copy_dir(src, dest, update=False, dryrun=False):
         if not dryrun:
-            distutils.dir_utils.copy_tree(src, dest, update)
+            distutils.dir_util.copy_tree(src, dest, update)


### PR DESCRIPTION
The non-cwd work in 7d4dbab broke being able to run atomicapp within a
container through the atomic cli command. This commit re-enables that
functionality, but not all pieces are working yet (i.e. atomic stop).