### PR TITLE
[WIP] Add "index" subcommand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ADD setup.py requirements.txt /opt/atomicapp/
 # lets install pip, and gcc for the native extensions
 # and remove all after use
 RUN yum -y install epel-release && \
-    yum install -y --setopt=tsflags=nodocs python-pip python-setuptools docker gcc && \
+    yum install -y --setopt=tsflags=nodocs GitPython python-pip python-setuptools docker gcc && \
     python setup.py install && \
     yum remove -y gcc cpp glibc-devel glibc-headers kernel-headers libmpc mpfr python-pip && \
     yum clean all

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -36,6 +36,7 @@ from atomicapp.constants import (__ATOMICAPPVERSION__,
 from atomicapp.nulecule import NuleculeManager
 from atomicapp.nulecule.exceptions import NuleculeException
 from atomicapp.utils import Utils
+from atomicapp.index import Index
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,15 @@ def cli_stop(args):
         logger.error(e, exc_info=True)
         sys.exit(1)
 
+def cli_index(args):
+    argdict = args.__dict__
+    i = Index(argdict["dryrun"])
+    if argdict["index_action"] == "generate":
+        i.generate(argdict["location"])
+    elif argdict["index_action"] == "list":
+        i.list()
+    elif argdict["index_action"] == "info":
+        i.info(argdict["app_id"])
 
 class CLI():
 
@@ -240,6 +250,31 @@ class CLI():
 
         parser_stop.set_defaults(func=cli_stop)
 
+        parser_index = subparsers.add_parser("index")
+        index_parsers = parser_index.add_subparsers(dest="index_action")
+        
+        index_generate = index_parsers.add_parser("generate")
+        index_generate.add_argument(
+            "location",
+            help=(
+                "Path or Git repository link containing Nulecule applications "
+                "which will be part of the genrated index"))
+        index_generate.set_defaults(func=cli_index)
+        
+        index_list = index_parsers.add_parser("list")
+        index_list.add_argument(
+            "--format",
+            help=("Blah"))
+        index_list.set_defaults(func=cli_index)
+
+        index_info = index_parsers.add_parser("info")
+        index_info.add_argument(
+            "app_id",
+            help=("Id of an application listed in index."))
+        index_info.set_defaults(func=cli_index)
+
+           
+
     def run(self):
         self.set_arguments()
         args = self.parser.parse_args()
@@ -252,7 +287,7 @@ class CLI():
 
         lock = LockFile(os.path.join(Utils.getRoot(), LOCK_FILE))
         try:
-            lock.acquire(timeout=-1)
+            #lock.acquire(timeout=-1)
             args.func(args)
         except AttributeError:
             if hasattr(args, 'func'):

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -55,3 +55,4 @@ DEFAULT_ANSWERS = {
     }
 }
 PROVIDER_CONFIG_KEY = "providerconfig"
+DEFAULT_INDEX_IMAGE = "nulecule/index"

--- a/atomicapp/index.py
+++ b/atomicapp/index.py
@@ -1,0 +1,137 @@
+"""
+ Copyright 2015 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+# Based on https://github.com/DBuildService/dock/blob/master/dock/plugin.py
+
+from __future__ import print_function
+import os
+
+import imp
+
+import logging
+from utils import Utils
+from constants import DEFAULT_INDEX_IMAGE
+from nulecule.base import Nulecule
+from nulecule.container import DockerHandler
+
+from git import Repo
+import tempfile
+from copy import deepcopy
+
+
+import anymarkup
+
+logger = logging.getLogger(__name__)
+
+
+class Index(object):
+    index_template = {"location": "", "nulecules": []}
+   
+    def __init__(self, dryrun=False):
+        self.dryrun = dryrun
+        self.index = deepcopy(self.index_template)
+        self._load_index_file()
+
+    def generate(self, location):
+        self.index = deepcopy(self.index_template)
+        if not os.path.exists(location):
+            location = self._get_repo(location)
+
+        if not os.path.isdir(location):
+            raise Exception("Location has to be a directory")
+
+        for f in os.listdir(location):
+            nulecule_dir = os.path.join(location, f)
+            if f.startswith("."):
+                continue
+            if os.path.isdir(nulecule_dir):
+                index_info = self._nulecule_get_info(nulecule_dir)
+                index_info["path"] = f
+                self.index["nulecules"].append(index_info)
+
+        if len(index_info) > 0:
+            anymarkup.serialize_file(self.index, "gen_index.yaml", format="yaml")
+
+    def fetch(self, index_image=DEFAULT_INDEX_IMAGE):
+        dh = DockerHandler(self.dryrun)
+        dh.pull(index_image)
+        dh.extract(index_image, "/gen_index.yaml", ".")
+
+    def list(self):
+        for entry in self.index["nulecules"]:
+            print(("{}{:>%s}   {}" % (50-len(entry["metadata"]["name"]))).format(entry["metadata"]["name"], entry["id"], entry["metadata"]["appversion"]))
+
+    def info(self, app_id):
+
+        entry = self._get_entry(app_id)
+        if entry:
+            self._print_entry(entry)
+
+    def _nulecule_get_info(self, nulecule_dir):
+        index_info = {}
+        nulecule = Nulecule.load_from_path(
+            nulecule_dir, nodeps=True, dryrun=self.dryrun)
+        index_info["id"] = nulecule.id
+        index_info["metadata"] = nulecule.metadata
+        index_info["specversion"] = nulecule.specversion
+
+        providers_set = set()
+        for component in nulecule.components:
+            if component.artifacts:
+                if len(providers_set) == 0:
+                    providers_set = set(component.artifacts.keys())
+                else:
+                    providers_set = providers_set.intersection(set(component.artifacts.keys()))
+            print(providers_set)
+
+        index_info["providers"] = list(providers_set)
+        return index_info
+
+    def _get_entry(self, app_id):
+        for entry in self.index["nulecules"]:
+            if entry["id"] == app_id:
+                return entry
+        return None
+
+    def _print_entry(self, entry, tab=""):
+        for key, val in entry.iteritems():
+            if type(val) == dict:
+                print("%s%s:" % (tab,key))
+                self._print_entry(val, tab+"  ")
+            elif type(val) == list:
+                print("%s%s: %s" % (tab, key, ", ".join(val)))
+            else:
+                print("%s%s: %s" % (tab, key, val))
+        
+        if entry.get("path"):
+            print("\n\nInclude as a graph component:\n\n"
+                    "- name: %s\n" 
+                    "  source: docker://%s/%s" % (entry["id"], "projectatomic", entry["path"]))
+
+    def _load_index_file(self, index_file="gen_index.yaml"):
+        if os.path.exists(index_file):
+            self.index = anymarkup.parse_file(index_file)
+        else:
+            logger.warning("Couldn't load index file %s", index_file)
+
+    def _get_repo(self, git_link):
+        tmp = tempfile.mkdtemp(prefix="atomicapp-index-XXXXXX")
+        self.index["location"] = git_link
+        repo = Repo.clone_from(git_link, tmp)
+        return tmp


### PR DESCRIPTION
@kbsingh's idea of index and cccp was always very interesting for me. This PR adds new subcommand `index` which has then 3 verbs:

* list - to list Nulecule apps/components in the Index
* info - to print details about the app/component 
* generate - to generate the Index based on the local path or a git URL containing unpacked Nulecule apps/components

It operates on top of https://github.com/projectatomic/nulecule-library where I have sent another pull request which is needed for this to work properly - https://github.com/projectatomic/nulecule-library/pull/17

## Workflow

1. generate 
  * based on the content of `nulecule-library` generate `gen_index.yaml` (this is just a POC and WIP;) )
  * This step is normally not used by a user! This is used in a Dockerfile for Automated Build in `nulecule-library` to build an image containing index.yaml which is pulled and unpacked by `index list` and `index info` if the index file is missing locally - works already as I set up the Automated Build for my other PR branch (image: `nulecule/index`)
2. list - parse `gen_index.yaml` and list all available apps/components
![screenshot from 2015-11-07 14-34-33](https://cloud.githubusercontent.com/assets/4759808/11015402/d2d35364-855d-11e5-9755-3495ff6e9f3d.png)
3. info - print info for a specific component and suggest a way how to add a component to your app
![screenshot from 2015-11-07 14-43-39](https://cloud.githubusercontent.com/assets/4759808/11015404/f57e32bc-855d-11e5-8225-f610f3584ff6.png)

I haven't tried to map it to `atomic` command anyhow yet..:(

## Reasoning

This `index` functionality can later be used by other tools to query available component and information about them (searching, filtering, automated addition of components...). It will also help developers to find components for their apps easily using Atomic App directly.

I'd also like to see filtering being added for the `list` verb to make it easy to search for f.e.
* Apps with a specific version of the Nulecule spec (`--filter=specversion=0.02`)
* Apps supporting specific provider (`--filter=provider=docker`)
* Apps with a some name (`--filter=id=mysql*`)


Comments are very welcome:-)