### PR TITLE
raise exception when running --dry-run without installed atomicapp components

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -108,7 +108,7 @@ class Nulecule(NuleculeBase):
         """
         nulecule_path = os.path.join(src, MAIN_FILE)
         if dryrun and not os.path.exists(nulecule_path):
-            return
+            raise NuleculeException("Installed Nulecule components are required to initiate dry-run")
         nulecule_data = anymarkup.parse_file(nulecule_path)
         nulecule = Nulecule(config=config, basepath=src,
                             namespace=namespace, **nulecule_data)


### PR DESCRIPTION
Quick PR for raising an exception if using --dry-run without any Nulecule components

Fixes #363