### PR TITLE
Merge config sets value for key if it or it's value is missing at source

### DIFF
--- a/atomicapp/nulecule/lib.py
+++ b/atomicapp/nulecule/lib.py
@@ -66,7 +66,7 @@ class NuleculeBase(object):
         for group, group_vars in from_config.items():
             to_config[group] = to_config.get(group) or {}
             for key, value in (group_vars or {}).items():
-                if key not in to_config[group]:
+                if to_config[group].get(key) is None:
                     to_config[group][key] = value
 
     def get_context(self):


### PR DESCRIPTION
Fixes #385

# Issue
When merging config data, we're initially checking whether a ``key`` exists in a section or not. If the ``key`` is missing in the section, then only we set it's value from data coming from child nulecule components. This failed in cases, like:
```
[some_section]
key1=None
key2=None
```

# Solution

We now set the value for a key if it is missing in the section, or it's value is None.