### PR TITLE
Change tmp dir location

### DIFF
--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -117,7 +117,7 @@ class Utils(object):
 
     @staticmethod
     def sanitizeName(app):
-        return app.replace("/", "-")
+        return app.replace("/", "-").replace(":", "-")
 
     @staticmethod
     def getNewAppCacheDir(image):


### PR DESCRIPTION
Imo, we should be extracting to 

`/var/lib/atomicapp/projectatomic-helloapache-latest-cf68076601d3` 
rather than 
`/var/lib/atomicapp/projectatomic-helloapache:latest-cf68076601d3`

Since metacharacters within dir names is bad practice. (including semicolons, spaces, backslashes, dollar signs, question marks, and asterisks)