### PR TITLE
Clean up CLI answers-format option

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -143,9 +143,8 @@ class CLI():
             "--answers-format",
             dest="answers_format",
             default=ANSWERS_FILE_SAMPLE_FORMAT,
-            help=(
-                "The format for the answers.conf.sample file.Default is "
-                "'ini', Valid formats are 'ini', 'json', 'xml', 'yaml'."))
+            choices=['ini', 'json', 'xml', 'yml'],
+            help="The format for the answers.conf.sample file. Default: %s" % ANSWERS_FILE_SAMPLE_FORMAT)
 
         subparsers = self.parser.add_subparsers(dest="action")
 


### PR DESCRIPTION
This cleans up part of the CLI to show the default answers-format more intuitively and remove the uneeded help statement.

new:
```
optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show the version and exit.
  -v, --verbose         Verbose output mode.
  -q, --quiet           Quiet output mode.
  --dry-run             Don't actually call provider. The commands that should
                        be run will be sent to stdout but not run.
  --answers-format {ini,json,xml,yml}
                        The format for the answers.conf.sample file.
```