### PR TITLE
Lib.py should load plugins in init

### DIFF
--- a/atomicapp/nulecule/lib.py
+++ b/atomicapp/nulecule/lib.py
@@ -5,9 +5,6 @@ from atomicapp.constants import (GLOBAL_CONF, DEFAULT_PROVIDER,
 from atomicapp.utils import Utils
 from atomicapp.plugin import Plugin
 
-plugin = Plugin()
-plugin.load_plugins()
-
 
 class NuleculeBase(object):
     """
@@ -15,6 +12,8 @@ class NuleculeBase(object):
     atomicapp.nulecule.base.
     """
     def __init__(self, basepath, params, namespace):
+        self.plugin = Plugin()
+        self.plugin.load_plugins()
         self.basepath = basepath
         self.params = params or []
         self.namespace = namespace
@@ -93,7 +92,7 @@ class NuleculeBase(object):
         if provider_key is None:
             provider_key = self.config.get(GLOBAL_CONF, {}).get(
                 PROVIDER_KEY, DEFAULT_PROVIDER)
-        provider_class = plugin.getProvider(provider_key)
+        provider_class = self.plugin.getProvider(provider_key)
         return provider_key, provider_class(
             self.get_context(), self.basepath, dry)
 


### PR DESCRIPTION
We shouldn't be loading plugins in file import, but rather in _init.

This blocks my logging PR as debug messages are incorrectly being displayed without --verbose being passed through. (set_logging within `cli/main.py` isn't set before loading `nulecule/lib.py`). We should be loading plugins via init of NuleculeManager.

Don't know why this was outside of the class in the first place. Tests and everything seem to pass!

Ping @rtnpro since it relates to your refactor.