### PR TITLE
Don't run container to extract files.

### DIFF
--- a/atomicapp/nulecule/container.py
+++ b/atomicapp/nulecule/container.py
@@ -76,8 +76,8 @@ class DockerHandler(object):
 
         # Create dummy container
         run_cmd = [
-            self.docker_cli, 'run', '-d', '--entrypoint', '/bin/true', image]
-        logger.debug('Running Docker container: %s' % ' '.join(run_cmd))
+            self.docker_cli, 'create', '--entrypoint', '/bin/true', image]
+        logger.debug('Creating docker container: %s' % ' '.join(run_cmd))
         container_id = subprocess.check_output(run_cmd).strip()
 
         # Copy files out of dummy container to tmpdir


### PR DESCRIPTION
In the past we didn't run a container to extract files but in cb0625b
we started doing that to workaround bug [1]. Now that the bug is fixed
let's revert back to just creating the containers and not actually
running them. This allows us to support nulecule metadata containers
that just contain nulecule metadata in them and are build "FROM scratch".

[1] - https://bugzilla.redhat.com/show_bug.cgi?id=1252168