### PR TITLE
Fix tests not removing answers.conf.gen

### DIFF
--- a/tests/units/cli/test_cli.py
+++ b/tests/units/cli/test_cli.py
@@ -19,8 +19,6 @@
 
 import os
 import sys
-import logging
-import shutil
 import json
 
 import unittest
@@ -28,8 +26,9 @@ import pytest
 
 import atomicapp.cli.main
 
+
 class TestCli(unittest.TestCase):
-    
+
     def exec_cli(self, command):
         saved_args = sys.argv
         sys.argv = command
@@ -38,20 +37,22 @@ class TestCli(unittest.TestCase):
 
     def is_json(self, myjson):
         try:
-            json_object = json.loads(myjson)
-        except ValueError, e:
+            json.loads(myjson)
+        except ValueError:
             return False
         return True
 
     def setUp(self):
-        logger = logging.getLogger('atomicapp.tests')
         self.examples_dir = os.path.dirname(__file__) + '/test_examples/'
 
-    def tearDown(self):
-        top = self.examples_dir
+    @classmethod
+    def tearDownClass(cls):
+        top = os.path.dirname(__file__) + '/test_examples/'
         for root, dirs, files in os.walk(top):
             for f in files:
                 if f.startswith('.'):
+                    os.remove(os.path.join(root, f))
+                elif f == "answers.conf.gen":
                     os.remove(os.path.join(root, f))
 
     def test_run_helloapache_app(self):
@@ -63,7 +64,7 @@ class TestCli(unittest.TestCase):
             "run",
             self.examples_dir + 'helloapache/'
         ]
-        
+
         # Run the dry-run command
         with pytest.raises(SystemExit) as exec_info:
             self.exec_cli(command)
@@ -97,7 +98,7 @@ class TestCli(unittest.TestCase):
             "--provider=docker",
             self.examples_dir + 'helloapache/'
         ]
-        
+
         with pytest.raises(SystemExit) as exec_info:
             self.exec_cli(command)
 
@@ -167,7 +168,7 @@ class TestCli(unittest.TestCase):
             self.exec_cli(command)
 
         assert exec_info.value.code == 0
-  
+
     def test_run_k8s_app_multiple_artifacts(self):
         command = [
             "main.py",
@@ -197,4 +198,3 @@ class TestCli(unittest.TestCase):
             self.exec_cli(command)
 
         assert exec_info.value.code == 0
-

--- a/tests/units/cli/test_cli_gitlab_example.py
+++ b/tests/units/cli/test_cli_gitlab_example.py
@@ -19,13 +19,12 @@
 
 import os
 import sys
-import logging
-import shutil
 
 import unittest
 import pytest
 
 import atomicapp.cli.main
+
 
 class TestGitLabCli(unittest.TestCase):
 
@@ -36,11 +35,10 @@ class TestGitLabCli(unittest.TestCase):
         sys.argv = saved_args
 
     def setUp(self):
-        logger = logging.getLogger('atomicapp.tests')
         self.examples_dir = os.path.dirname(__file__) + '/test_examples/'
         self.answers_conf = os.path.join(
-                self.examples_dir,
-                "gitlab/answers.conf.sample")
+            self.examples_dir,
+            "gitlab/answers.conf.sample")
 
         # "work dir" of the kubernetes artifacts
         self.work_dir = os.path.join(
@@ -49,26 +47,33 @@ class TestGitLabCli(unittest.TestCase):
 
         # A list of artifacts that should be there during install / run / stop
         self.artifacts_array = [
-                "gitlab-http-service.json",
-                ".gitlab-http-service.json",
-                "gitlab-rc.json",
-                ".gitlab-rc.json",
-                "postgres-rc.json",
-                ".postgres-rc.json",
-                "postgres-service.json",
-                ".postgres-service.json",
-                "redis-rc.json",
-                ".redis-rc.json",
-                "redis-service.json",
-                ".redis-service.json"]
+            "gitlab-http-service.json",
+            ".gitlab-http-service.json",
+            "gitlab-rc.json",
+            ".gitlab-rc.json",
+            "postgres-rc.json",
+            ".postgres-rc.json",
+            "postgres-service.json",
+            ".postgres-service.json",
+            "redis-rc.json",
+            ".redis-rc.json",
+            "redis-service.json",
+            ".redis-service.json"]
 
-    # Remove the examples answers.conf file as well as the dotfiles created 
+    # Remove the examples answers.conf file as well as the dotfiles created
     def tearDown(self):
         if os.path.isfile(self.answers_conf):
-           os.remove(self.answers_conf)
-        for f in os.listdir(self.work_dir):
-            if f.startswith('.'):
-                os.remove(self.work_dir + f)
+            os.remove(self.answers_conf)
+
+    @classmethod
+    def tearDownClass(cls):
+        top = os.path.dirname(__file__) + '/test_examples/'
+        for root, dirs, files in os.walk(top):
+            for f in files:
+                if f.startswith('.'):
+                    os.remove(os.path.join(root, f))
+                elif f == "answers.conf.gen":
+                    os.remove(os.path.join(root, f))
 
     # Installs the gitlab example similarly to `test_cli.py` examples
     def test_install_gitlab_app(self):


### PR DESCRIPTION
This commit fixes answers.conf.gen not being removed after a failed
test.

Flake8 was also ran on both test_cli.py and gitlab testing files.
Logging and shutil dependancies were removed due to no use from them (we
collect the log anyways on test ran).