### PR TITLE
Adds more information to running --dry-run

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -111,7 +111,8 @@ class Nulecule(NuleculeBase):
         """
         nulecule_path = os.path.join(src, MAIN_FILE)
         if dryrun and not os.path.exists(nulecule_path):
-            raise NuleculeException("Installed Nulecule components are required to initiate dry-run")
+            raise NuleculeException("Installed Nulecule components are required to initiate dry-run. "
+                                    "Please specify your app via atomicapp --dry-run /path/to/your-app")
         nulecule_data = anymarkup.parse_file(nulecule_path)
         nulecule = Nulecule(config=config, basepath=src,
                             namespace=namespace, **nulecule_data)


### PR DESCRIPTION
More information when running `sudo atomicapp -v --dry-run run APP`, since we are required to provide the actual extracted Nulecule application as a form of a path rather than a docker-image.