### PR TITLE
Remove container on stopping on Docker provider. Fixes #389

### DIFF
--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -127,9 +127,18 @@ class DockerProvider(Provider):
             else:
                 m = re.match("%s_+%s+_+[a-zA-Z0-9]{12}" % (self.namespace, self.image), container)
             if m:
-                logger.info("STOPPING CONTAINER: %s", container)
-                cmd = ["docker", "kill", container]
+                logger.info("STOPPING AND REMOVING CONTAINER: %s", container)
+                cmd_list = [
+                    ["docker", "kill", container],
+                    ["docker", "rm", container]
+                ]
                 if self.dryrun:
-                    logger.info("DRY-RUN: STOPPING CONTAINER %s", " ".join(cmd))
+                    logger.info(
+                        "DRY-RUN: STOPPING CONTAINER %s", " ".join(
+                            cmd_list[0]))
+                    logger.info(
+                        "DRY-RUN: REMOVING CONTAINER %s", " ".join(
+                            cmd_list[1]))
                 else:
-                    subprocess.check_call(cmd)
+                    for cmd in cmd_list:
+                        subprocess.check_call(cmd)


### PR DESCRIPTION
Pods, services, etc. are a first class entity on a Kubernetes
provider, and they get deleted when the provider is stopped.
In the same way, containers, which are a first class entity
on Docker provider, should also get deleted when the provider
is stopped.