### PR TITLE
Add persistent storage

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -40,6 +40,12 @@ NAME_KEY = "name"
 DEFAULTNAME_KEY = "default"
 PROVIDER_KEY = "provider"
 NAMESPACE_KEY = "namespace"
+REQUIREMENTS_KEY = "requirements"
+
+# Nulecule spec terminology vs the function within /providers
+REQUIREMENT_FUNCTIONS = {
+    "persistentVolume": "persistent_storage"
+}
 
 MAIN_FILE = "Nulecule"
 ANSWERS_FILE = "answers.conf"

--- a/atomicapp/providers/external/kubernetes/persistent_storage.yaml
+++ b/atomicapp/providers/external/kubernetes/persistent_storage.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: $name
+spec:
+  accessModes:
+    - $accessMode
+  resources:
+    requests:
+      storage: $size

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -20,6 +20,7 @@
 import anymarkup
 import logging
 import os
+from string import Template
 
 from atomicapp.plugin import Provider, ProviderFailedException
 from atomicapp.utils import printErrorStatus, Utils
@@ -204,3 +205,37 @@ class KubernetesProvider(Provider):
             if self.config_file:
                 cmd.append("--kubeconfig=%s" % self.config_file)
             self._call(cmd)
+
+    def persistent_storage(self, graph, action):
+        """
+        Actions are either: run, stop or uninstall as per the Requirements class
+        Curently run is the only function implemented for k8s persistent storage
+        """
+
+        logger.debug("Persistent storage enabled! Running action: %s" % action)
+
+        if action not in ['run']:
+            logger.warning(
+                "%s action is not available for provider %s. Doing nothing." %
+                (action, self.key))
+            return
+
+        # Get the path of the persistent storage yaml file includes in /external
+        # Plug the information from the graph into the persistent storage file
+        base_path = os.path.dirname(os.path.realpath(__file__))
+        template_path = os.path.join(base_path,
+                                     'external/kubernetes/persistent_storage.yaml')
+        with open(template_path, 'r') as f:
+            content = f.read()
+        template = Template(content)
+        rendered_template = template.safe_substitute(graph)
+
+        tmp_file = Utils.getTmpFile(rendered_template, '.yaml')
+
+        # Pass the .yaml file and execute
+        if action is "run":
+            cmd = [self.kubectl, "create", "-f", tmp_file, "--namespace=%s" % self.namespace]
+            if self.config_file:
+                cmd.append("--kubeconfig=%s" % self.config_file)
+            self._call(cmd)
+            os.unlink(tmp_file)

--- a/atomicapp/requirements.py
+++ b/atomicapp/requirements.py
@@ -1,0 +1,79 @@
+import logging
+
+from atomicapp.constants import REQUIREMENT_FUNCTIONS
+from atomicapp.plugin import Plugin
+
+logger = logging.getLogger(__name__)
+
+
+class Requirements:
+
+    """
+    Requirements will search what is currently being used under
+    the requirements section of Nulecule and deploy in accordance
+    to the graph variables as well as whether or not said requirement
+    exists within the provider.
+
+    The REQUIREMENTS_FUNCTIONS dictionary maps all current requirement
+    names to the function names for each provider.
+
+    For example, the persistentVolume requirement in Nulecule is mapped as
+    the persistent_storage function within each provider.
+
+    Requirements tries to be as modular as possible.
+    """
+
+    def __init__(self, config, basepath, graph, provider, dryrun):
+        self.plugin = Plugin()
+        self.plugin.load_plugins()
+
+        self.config = config
+        self.basepath = basepath
+        self.graph = graph
+        self.dryrun = dryrun
+
+        # We initialize the provider in order to gather provider-specific
+        # information
+        p = self.plugin.getProvider(provider)
+        self.provider = p(config, basepath, dryrun)
+        self.provider.init()
+
+    def run(self):
+        self._exec("run")
+
+    def stop(self):
+        self._exec("stop")
+
+    def uninstall(self):
+        self._exec("uninstall")
+
+    # Find if the requirement does not exist within REQUIREMENT_FUNCTIONS
+    def _find_requirement_function_name(self, key):
+        logging.debug("Checking if %s matches any of %s" %
+                      (key, REQUIREMENT_FUNCTIONS))
+        if key in REQUIREMENT_FUNCTIONS.keys():
+            return REQUIREMENT_FUNCTIONS[key]
+        raise RequirementFailedException("Requirement %s does not exist." % key)
+
+    # We loop through the given requirements graph and
+    # execute each passed requirement
+    def _exec(self, action):
+        for req in self.graph:
+            key_name = req.keys()[0]
+            requirement_function = self._find_requirement_function_name(key_name)
+
+            # Check to see if the function exists in the provider,
+            # if it does not: fail
+            try:
+                requirement = getattr(self.provider, requirement_function)
+            except AttributeError:
+                raise RequirementFailedException(
+                    "Requirement %s does not exist within %s." %
+                    (requirement_function, self.provider))
+
+            # Run the requirement function
+            requirement(req[key_name], action)
+
+
+class RequirementFailedException(Exception):
+    pass

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -186,6 +186,15 @@ class Utils(object):
     def getTmpAppDir(self):
         return os.path.join(self.tmpdir, APP_ENT_PATH)
 
+    # Create a temporary file with data in order to use kubectl, openshift, etc.
+    # Returns the tmp dir and name of the file
+    @staticmethod
+    def getTmpFile(data, suffix=''):
+        f = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        f.write(data)
+        f.close()
+        return f.name
+
     @staticmethod
     def getComponentName(graph_item):
         # logger.debug("Getting name for %s", graph_item)

--- a/setup.py
+++ b/setup.py
@@ -40,16 +40,18 @@ def _install_requirements():
     return requirements
 
 setup(
-    name = 'atomicapp',
-    version = '0.3.0',
-    description = 'A tool to install and run Nulecule apps',
-    author = 'Red Hat, Inc.',
-    author_email = 'container-tools@redhat.com',
-    url = 'https://github.com/projectatomic/atomicapp',
-    license = "LGPL3",
-    entry_points = {
+    name='atomicapp',
+    version='0.3.0',
+    description='A tool to install and run Nulecule apps',
+    author='Red Hat, Inc.',
+    author_email='container-tools@redhat.com',
+    url='https://github.com/projectatomic/atomicapp',
+    license="LGPL3",
+    entry_points={
         'console_scripts': ['atomicapp=atomicapp.cli.main:main'],
     },
-    packages = find_packages(),
-    install_requires = _install_requirements()
+    packages=find_packages(),
+    package_data={'atomicapp': ['providers/external/kubernetes/*.yaml']},
+    include_package_data=True,
+    install_requires=_install_requirements()
 )

--- a/tests/units/persistent_storage/test_examples/ps-helloapache/Nulecule
+++ b/tests/units/persistent_storage/test_examples/ps-helloapache/Nulecule
@@ -1,0 +1,31 @@
+---
+specversion: 0.0.2
+id: helloapache-app
+
+metadata:
+  name: Hello Apache App
+  appversion: 0.0.1
+  description: Atomic app for deploying a really basic Apache HTTP server
+graph:
+  - name: helloapache-app
+    params:
+      - name: image
+        description: The webserver image
+        default: centos/httpd
+      - name: hostport
+        description: The host TCP port as the external endpoint
+        default: 80
+    artifacts:
+      docker:
+        - file://artifacts/docker/hello-apache-pod_run
+      kubernetes:
+        - file://artifacts/kubernetes/hello-apache-pod.json
+    requirements:
+      - persistentVolume:
+          name: "var-lib-mongodb-data"
+          accessMode: "ReadWrite"
+          size: 4
+      - persistentVolume:
+          name: "var-log-mongodb"
+          accessMode: "ReadWrite"
+          size: 4

--- a/tests/units/persistent_storage/test_examples/ps-helloapache/answers.conf.sample
+++ b/tests/units/persistent_storage/test_examples/ps-helloapache/answers.conf.sample
@@ -1,0 +1,10 @@
+{
+  "helloapache-app": {
+    "image": "centos/httpd",
+    "hostport": 80
+  },
+  "general": {
+    "namespace": "default",
+    "provider": "kubernetes"
+  }
+}

--- a/tests/units/persistent_storage/test_examples/ps-helloapache/artifacts/docker/hello-apache-pod_run
+++ b/tests/units/persistent_storage/test_examples/ps-helloapache/artifacts/docker/hello-apache-pod_run
@@ -1,0 +1,1 @@
+docker run -d -p $hostport:80 $image

--- a/tests/units/persistent_storage/test_examples/ps-helloapache/artifacts/kubernetes/hello-apache-pod.json
+++ b/tests/units/persistent_storage/test_examples/ps-helloapache/artifacts/kubernetes/hello-apache-pod.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "labels": {
+            "app": "helloapache"
+        },
+        "name": "helloapache"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "$image",
+                "name": "helloapache",
+                "ports": [
+                    {
+                        "containerPort": 80,
+                        "hostPort": $hostport,
+                        "protocol": "TCP"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/units/persistent_storage/test_ps.py
+++ b/tests/units/persistent_storage/test_ps.py
@@ -1,0 +1,36 @@
+import unittest
+import tempfile
+from atomicapp.requirements import Requirements, RequirementFailedException
+
+
+class TestPersistentStorage(unittest.TestCase):
+
+    # Create a tmp dir and add graph and config information
+
+    def setUp(self):
+        config = {'helloapache-app': {'image': 'centos/httpd', 'hostport': 80},
+                  'general': {'namespace': 'default', 'provider': 'kubernetes'}}
+        graph = [{'persistentVolume': {'accessMode': 'ReadWrite', 'name': 'var-lib-mongodb-data', 'size': 4}},
+                 {'persistentVolume': {'accessMode': 'ReadWrite', 'name': 'var-log-mongodb', 'size': 4}}]
+        self.tmpdir = tempfile.mkdtemp(prefix="atomicapp-test", dir="/tmp")
+        self.test = Requirements(
+            config=config, basepath=self.tmpdir, graph=graph, provider="kubernetes", dryrun=True)
+
+    def tearDown(self):
+        pass
+
+    def test_missing_requirement(self):
+        with self.assertRaises(RequirementFailedException) as context:
+            self.test._find_requirement_function_name('foo')
+
+        self.assertTrue("Requirement foo does not exist." in context.exception)
+
+    # Rest of these tests checks to see if dryrunning the provider passes correctly
+    def test_run(self):
+        self.test.run()
+
+    def test_stop(self):
+        self.test.stop()
+
+    def test_uninstall(self):
+        self.test.uninstall()

--- a/tests/units/persistent_storage/test_ps_cli.py
+++ b/tests/units/persistent_storage/test_ps_cli.py
@@ -1,0 +1,86 @@
+"""
+ Copyright 2015 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import os
+import sys
+import json
+
+import unittest
+import pytest
+
+import atomicapp.cli.main
+
+
+class TestCli(unittest.TestCase):
+
+    def exec_cli(self, command):
+        saved_args = sys.argv
+        sys.argv = command
+        atomicapp.cli.main.main()
+        sys.argv = saved_args
+
+    def is_json(self, myjson):
+        try:
+            json.loads(myjson)
+        except ValueError:
+            return False
+        return True
+
+    def setUp(self):
+        self.examples_dir = os.path.dirname(__file__) + '/test_examples/'
+
+    @classmethod
+    def tearDownClass(cls):
+        top = os.path.dirname(__file__) + '/test_examples/'
+        for root, dirs, files in os.walk(top):
+            for f in files:
+                if f.startswith('.'):
+                    os.remove(os.path.join(root, f))
+                elif f == "answers.conf.gen":
+                    os.remove(os.path.join(root, f))
+
+    def test_run_k8s_persistent_storage(self):
+        command = [
+            "main.py",
+            "--verbose",
+            "--dry-run",
+            "run",
+            "--provider=kubernetes",
+            self.examples_dir + 'ps-helloapache/'
+        ]
+
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        assert exec_info.value.code == 0
+
+    def test_stop_k8s_persistent_storage(self):
+        command = [
+            "main.py",
+            "--verbose",
+            "--dry-run",
+            "stop",
+            "--provider=kubernetes",
+            self.examples_dir + 'ps-helloapache/'
+        ]
+
+        with pytest.raises(SystemExit) as exec_info:
+            self.exec_cli(command)
+
+        assert exec_info.value.code == 0


### PR DESCRIPTION
__DONE:__

~~Initial work on persistent storage. Work's correctly. Just need to clean-up most of the code.~~

~~It's a Work-In-Progress so excuse the multiple log messages, but you get the gist of how I implemented it.~~

  - ~~Code comments / docs~~
  - ~~More tests!~~

```
Name                        Stmts   Miss  Cover   Missing
---------------------------------------------------------
atomicapp/requirements.py      36      3    92%   40, 43, 46
----------------------------------------------------------------------
Ran 5 tests in 0.009s
```
_tests cover 92% and under `kubernetes.py persistent_storage` function too_

  - ~~Clean up log messages~~

__TODO:__
 - [x] Grep `kubectl pvc` output or something to see if there is actually any persistent volumes yet for Kubernetes. Warn the user if so.
 - [x] Logs are a mess (this will be cleaned up in #134)
 - [ ] Documentation in Nulecule spec or nulecule-library example should be added. 
 - [x] Split into different commits

Notes:
 - For now this will **only** be for Kubernetes persistent storage. OpenShift will be added at a future date (Docker maybe too with the Flocker plugin).
 - Only **creating** persistent storage has been adding, no removing (yet?) we need to discuss this.


