### PR TITLE
Revert "Remove container on stopping on Docker provider. Fixes #389"

### DIFF
--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -127,18 +127,9 @@ class DockerProvider(Provider):
             else:
                 m = re.match("%s_+%s+_+[a-zA-Z0-9]{12}" % (self.namespace, self.image), container)
             if m:
-                logger.info("STOPPING AND REMOVING CONTAINER: %s", container)
-                cmd_list = [
-                    ["docker", "kill", container],
-                    ["docker", "rm", container]
-                ]
+                logger.info("STOPPING CONTAINER: %s", container)
+                cmd = ["docker", "kill", container]
                 if self.dryrun:
-                    logger.info(
-                        "DRY-RUN: STOPPING CONTAINER %s", " ".join(
-                            cmd_list[0]))
-                    logger.info(
-                        "DRY-RUN: REMOVING CONTAINER %s", " ".join(
-                            cmd_list[1]))
+                    logger.info("DRY-RUN: STOPPING CONTAINER %s", " ".join(cmd))
                 else:
-                    for cmd in cmd_list:
-                        subprocess.check_call(cmd)
+                    subprocess.check_call(cmd)


### PR DESCRIPTION
Reverts projectatomic/atomicapp#457

This commit doesn't work well when trying to docker stop and remove from inside a container. devicemapper will give an error. Reverting for now until we figure out what the issue is. 

See comments at the end of https://github.com/projectatomic/atomicapp/pull/457