### PR TITLE
Allow user to specify both source and destination as directories.

### DIFF
--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -61,10 +61,11 @@ class NuleculeManager(object):
         else:
             self.app_path = app_spec
 
-        # Doesn't make sense to provide an app path and destination
+        # Doesn't really make much sense to provide an app path and destination,
+        # but if they want to we'll simply just copy the files for them
         if self.app_path and destination:
-            raise NuleculeException(
-                "You can't provide a local path and destination.")
+            Utils.copy_dir(self.app_path, destination, update=True)
+            self.app_path = destination
 
         # If the user provided an image, make sure we have a destination
         if self.image:


### PR DESCRIPTION
This will allow the user to specify both a source path to a directory
with Nulecule metadata as well as a destination path where they would
like to new application to reside. This doesn't make sense in most
situations but could be useful in cases where we don't want to copy
data out of the container or in the case rtnpro stated in #400.

Closes #400.