### PR TITLE
Add --mode CLI switch. Argparser reorg. 

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -20,8 +20,7 @@
 import os
 import sys
 
-from argparse import ArgumentParser
-from argparse import RawDescriptionHelpFormatter
+import argparse
 import logging
 from lockfile import LockFile
 from lockfile import AlreadyLocked
@@ -100,16 +99,16 @@ def cli_stop(args):
 class CLI():
 
     def __init__(self):
-        self.parser = ArgumentParser(
+        self.parser = argparse.ArgumentParser(
             prog='atomicapp',
             description=(
                 "This will install and run an Atomic App, "
                 "a containerized application conforming to the Nulecule Specification"),
-            formatter_class=RawDescriptionHelpFormatter)
+            formatter_class=argparse.RawDescriptionHelpFormatter)
 
     def set_arguments(self):
 
-        base_parser = ArgumentParser(add_help=False)
+        base_parser = argparse.ArgumentParser(add_help=False)
 
         base_parser.add_argument(
             "-V",

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -113,10 +113,19 @@ class CLI():
         toplevel_parser = argparse.ArgumentParser(
             prog='atomicapp',
             formatter_class=argparse.RawDescriptionHelpFormatter,
+            add_help=False,
             description=(
                 "This will install and run an Atomic App, "
                 "a containerized application conforming to the Nulecule Specification"))
-
+        # Add a help function to the toplevel parser but don't output
+        # help information for it. We need this because of the way we
+        # are stitching help output together from multiple parsers
+        toplevel_parser.add_argument(
+            "-h",
+            "--help"
+            "--version",
+            action='help',
+            help=argparse.SUPPRESS)
         # Allow for subparsers of the toplevel_parser. Store the name
         # in the "action" attribute
         toplevel_subparsers = toplevel_parser.add_subparsers(dest="action")
@@ -242,6 +251,15 @@ class CLI():
                 "Path to the directory where the Atomic App is installed or "
                 "an image containing an Atomic App which should be stopped."))
         stop_subparser.set_defaults(func=cli_stop)
+
+        # Some final fixups.. We want the "help" from the global
+        # parser to be output when someone runs 'atomicapp --help'
+        # To get that functionality we will add the help from the
+        # globals parser to the epilog of the toplevel parser and also
+        # suppress the usage message from being output from the
+        # globals parser.
+        globals_parser.usage = argparse.SUPPRESS
+        toplevel_parser.epilog = globals_parser.format_help()
 
         # Return the toplevel parser
         return toplevel_parser

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -156,6 +156,18 @@ class CLI():
             action="store_true",
             help="Quiet output mode.")
         globals_parser.add_argument(
+            "--mode",
+            dest="mode",
+            default=None,
+            choices=['install', 'run', 'stop'],
+            help=('''
+                 The mode Atomic App is run in. This option has the
+                 effect of switching the 'verb' that was passed by the
+                 user as the first positional argument. This is useful
+                 in cases where a user is not using the Atomic App cli
+                 directly, but through another interface such as the
+                 Atomic CLI.'''))
+        globals_parser.add_argument(
             "--dry-run",
             dest="dryrun",
             default=False,
@@ -280,12 +292,18 @@ class CLI():
         # keyword. In order to handle this we just need to figure out
         # what subparser will be used and move it's keyword to the front
         # of the line.
+        # NOTE: Also allow "mode" to override 'action' if specified
         args, _ = self.parser.parse_known_args(cmdline)
         cmdline.remove(args.action)     # Remove 'action' from the cmdline
+        if args.mode:
+            args.action = args.mode     # Allow mode to override 'action'
         cmdline.insert(0, args.action)  # Place 'action' at front
+        logger.info("Action/Mode Selected is: %s" % args.action)
 
         # Finally, parse args and give error if necessary
         args = self.parser.parse_args(cmdline)
+
+        # Set logging level
         if args.verbose:
             set_logging(level=logging.DEBUG)
         elif args.quiet:


### PR DESCRIPTION
In order to change the mode of the application easily when using
Atomic CLI it would be nice to have a way to change the mode even
though we were run through the "run" action.

This could be useful for accessing actions that aren't available in
Atomic CLI or ones that haven't yet been added to atomic CLI.

For example, if we add 'atomicapp takeoverworld' to Atomic App in
order to use it through Atomic CLI we would simply need to run:
`atomic run <IMAGE> --mode=takeoverworld`.