### PR TITLE
fix AttributeError OpenshiftClient.ssl_verify

### DIFF
--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -34,9 +34,10 @@ logger = logging.getLogger(__name__)
 
 class OpenshiftClient(object):
 
-    def __init__(self, openshift_api, kubernetes_api):
+    def __init__(self, openshift_api, kubernetes_api, ssl_verify):
         self.openshift_api = openshift_api
         self.kubernetes_api = kubernetes_api
+        self.ssl_verify = ssl_verify
 
     def get_oapi_resources(self):
         """
@@ -140,7 +141,7 @@ class OpenShiftProvider(Provider):
         logger.debug("kubernetes_api = %s", self.kubernetes_api)
         logger.debug("openshift_api = %s", self.openshift_api)
 
-        self.oc = OpenshiftClient(self.openshift_api, self.kubernetes_api)
+        self.oc = OpenshiftClient(self.openshift_api, self.kubernetes_api, self.ssl_verify)
         self.oapi_resources = self.oc.get_oapi_resources()
         self.kapi_resources = self.oc.get_kapi_resources()
 


### PR DESCRIPTION
Openshift provider throws AttributeError.
This should fix it for now.

More and cleaner work on handling SSL comming soon.

```
2015-12-22 14:08:45,883 - __main__ - INFO - Action/Mode Selected is: run
2015-12-22 14:08:45,913 - __main__ - ERROR - 'OpenshiftClient' object has no attribute 'ssl_verify'
Traceback (most recent call last):
  File "/opt/atomicapp/atomicapp/cli/main.py", line 98, in cli_run
    nm.run(**argdict)
  File "/opt/atomicapp/atomicapp/nulecule/main.py", line 245, in run
    self.nulecule.run(cli_provider, dryrun)
  File "/opt/atomicapp/atomicapp/nulecule/base.py", line 136, in run
    component.run(provider_key, dryrun)
  File "/opt/atomicapp/atomicapp/nulecule/base.py", line 264, in run
    provider.init()
  File "/opt/atomicapp/atomicapp/providers/openshift.py", line 144, in init
    self.oapi_resources = self.oc.get_oapi_resources()
  File "/opt/atomicapp/atomicapp/providers/openshift.py", line 49, in get_oapi_resources
    verify=self.ssl_verify)
AttributeError: 'OpenshiftClient' object has no attribute 'ssl_verify'
(atomicapp)
```