### PR TITLE
openshift provider: add option for skiping tls verification

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -70,3 +70,5 @@ PROVIDERS = ["docker", "kubernetes", "openshift", "marathon"]
 PROVIDER_API_KEY = "providerapi"
 ACCESS_TOKEN_KEY = "accesstoken"
 PROVIDER_CONFIG_KEY = "providerconfig"
+PROVIDER_TLS_VERIFY_KEY = "providertlsverify"
+PROVIDER_CA_KEY = "providercafile"

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -53,6 +53,11 @@ class OpenshiftClient(object):
             ProviderFailedException - Invalid SSL/TLS certificate
         """
         logger.debug("Testing connection to OpenShift server")
+
+        if self.provider_ca and not os.path.exists(self.provider_ca):
+            raise ProviderFailedException("Unable to find CA path %s"
+                                          % self.provider_ca)
+
         try:
             (status_code, return_data) = \
                 Utils.make_rest_request("get",
@@ -643,5 +648,10 @@ class OpenShiftProvider(Provider):
         self.providerapi = result[PROVIDER_API_KEY]
         self.access_token = result[ACCESS_TOKEN_KEY]
         self.namespace = result[NAMESPACE_KEY]
-        self.provider_ca = result[PROVIDER_CA_KEY]
         self.provider_tls_verify = result[PROVIDER_TLS_VERIFY_KEY]
+        if result[PROVIDER_CA_KEY]:
+            # if we are in container translate path to path on host
+            self.provider_ca = os.path.join(Utils.getRoot(),
+                                            result[PROVIDER_CA_KEY].lstrip('/'))
+        else:
+            self.provider_ca = None

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -520,9 +520,8 @@ class OpenShiftProvider(Provider):
             namespace = context["context"]["namespace"]
         if "insecure-skip-tls-verify" in cluster["cluster"]:
             tls_verify = not cluster["cluster"]["insecure-skip-tls-verify"]
-        else:
-            if "certificate-authority" in cluster["cluster"]:
-                ca = cluster["cluster"]["certificate-authority"]
+        elif "certificate-authority" in cluster["cluster"]:
+            ca = cluster["cluster"]["certificate-authority"]
 
         return {PROVIDER_API_KEY: url,
                 ACCESS_TOKEN_KEY: token,
@@ -567,11 +566,11 @@ class OpenShiftProvider(Provider):
         # decide between values from answers.conf and providerconfig
         # if only one is set use that, report if they are in conflict
         for k in result.keys():
-            if answers[k] != None and providerconfig[k] == None:
+            if answers[k] is not None and providerconfig[k] is None:
                 result[k] = answers[k]
-            if answers[k] == None and providerconfig[k] != None:
+            if answers[k] is None and providerconfig[k] is not None:
                 result[k] = providerconfig[k]
-            if answers[k] != None and providerconfig[k] != None:
+            if answers[k] is not None and providerconfig[k] is not None:
                 if answers[k] == providerconfig[k]:
                     result[k] = answers[k]
                 else:

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -115,7 +115,7 @@ class OpenshiftClient(object):
         (status_code, return_data) = \
             Utils.make_rest_request("delete",
                                     url,
-                                    verify=self.ssl_verify)
+                                    verify=self._requests_tls_verify())
         if status_code == 200:
             logger.info("Sucessfully deleted.")
         else:
@@ -259,7 +259,7 @@ class OpenShiftProvider(Provider):
                                     "replicationcontroller",
                                     params=params)
                 (status_code, return_data) = \
-                    Utils.make_rest_request("get", url, verify=self.ssl_verify)
+                    Utils.make_rest_request("get", url, verify=self.oc._requests_tls_verify())
                 if status_code != 200:
                     raise ProviderFailedException("Cannot get Replication"
                                                   "Controllers for Deployment"
@@ -285,7 +285,7 @@ class OpenShiftProvider(Provider):
                 params = {"labelSelector": selector}
                 url = self._get_url(namespace, "pod", params=params)
                 (status_code, return_data) = \
-                    Utils.make_rest_request("get", url, verify=self.ssl_verify)
+                    Utils.make_rest_request("get", url, verify=self.oc._requests_tls_verify())
                 if status_code != 200:
                     raise ProviderFailedException("Cannot get Pods for "
                                                   "ReplicationController %s"

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -602,6 +602,13 @@ class OpenShiftProvider(Provider):
 
         logger.debug("config values: %s" % result)
 
+        # this items are required, they have to be not None
+        for k in [PROVIDER_API_KEY, ACCESS_TOKEN_KEY, NAMESPACE_KEY]:
+            if result[k] is None:
+                msg = "You need to set %s in %s" % (k, ANSWERS_FILE)
+                logger.error(msg)
+                raise ProviderFailedException(msg)
+
         # set config values
         self.providerapi = result[PROVIDER_API_KEY]
         self.access_token = result[ACCESS_TOKEN_KEY]

--- a/docs/providers/openshift/overview_atomic_app.md
+++ b/docs/providers/openshift/overview_atomic_app.md
@@ -71,6 +71,31 @@ namespace = mynamespace
 `oc whoami -t` or if you are not using `oc` client you can get it 
 via web browser on `https://<openshift server>/oauth/token/request`
 
+#### providertlsverify
+If `providerapi` is using https protocol you can optionally
+disable verification of tls/ssl certificates. This can be especially
+useful when using self-signed certificates.
+
+```
+[general]
+provider = openshift
+providerapi = https://127.0.0.1:8443
+accesstoken = sadfasdfasfasfdasfasfasdfsafasfd
+namespace = mynamespace
+providertlsverify = False
+```
+
+**NOTE**: If `providerconfig` is used  values of `providertlsverify`
+and `providercafile` are set according to settings in `providerconfig` file.
+
+#### providercafile
+If `providerapi` is using https protocol you can optionally specify
+path to a CA_BAUNDLE file or directory with certificates of trusted CAs.
+
+**NOTE**: If `providerconfig` is used  values of `providertlsverify`
+and `providercafile` are set according to settings in `providerconfig` file.
+
+
 #### Configuration Value Defaults
 
 Table 1. OpenShift default configuration values
@@ -81,6 +106,8 @@ namespace|   no     | namespace to use with each kubectl call                 | 
 providerconfig| no  | config file that specifies how to connect to kubernetes | none
 providerapi|  no    | the API endpoint where API requests can be sent         | none
 accesstoken|  no    | the access token that can be used to authenticate       | none
+providertlsverify|no| turn off verificatoin of tls/ssl certificates           | False
+providercafile| no  | path to file or directory with trusted CAs              | none
 
 **NOTE**: One of `providerconfig` or `providerapi` + `accesstoken` are required
 

--- a/tests/units/providers/test_openshift_provider.py
+++ b/tests/units/providers/test_openshift_provider.py
@@ -27,6 +27,7 @@ class OpenshiftProviderTestMixin(object):
         """
         op = OpenShiftProvider({}, '.', dryrun)
         op.artifacts = artifacts
+        op.access_token = 'test'
         op.init()
         return op
 
@@ -58,7 +59,7 @@ class TestOpenshiftProviderDeploy(OpenshiftProviderTestMixin, unittest.TestCase)
         op.deploy()
 
         self.mock_oc.deploy.assert_called_once_with(
-            'namespaces/foo/pods/?access_token=None',
+            'namespaces/foo/pods/?access_token=test',
             op.openshift_artifacts['pods'][0])
 
     def test_deploy_dryrun(self):
@@ -107,7 +108,7 @@ class TestOpenshiftProviderUndeploy(OpenshiftProviderTestMixin, unittest.TestCas
         op.undeploy()
 
         self.mock_oc.delete.assert_called_once_with(
-            'namespaces/foo/pods/%s?access_token=None' %
+            'namespaces/foo/pods/%s?access_token=test' %
             op.openshift_artifacts['pods'][0]['metadata']['name'])
 
     def test_undeploy_dryrun(self):

--- a/tests/units/providers/test_openshift_provider.py
+++ b/tests/units/providers/test_openshift_provider.py
@@ -229,7 +229,7 @@ class TestOpenshiftProviderParseKubeconfData(OpenshiftProviderTestMixin, unittes
     def test_parse_kubeconf_data_insecure(self):
         """
         Test parsing kubeconf data with current context containing
-        cluster, user, namespace info and skiping tls verification
+        cluster, user, namespace info and skipping tls verification
         """
         kubecfg_data = {
             'current-context': 'context2',


### PR DESCRIPTION
get tls verification settings from `providerconfig` (kubectl config) or `answers.conf`

closes: #451 