### PR TITLE
Stop Docker containers more gracefully

### DIFF
--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -127,8 +127,8 @@ class DockerProvider(Provider):
             else:
                 m = re.match("%s_+%s+_+[a-zA-Z0-9]{12}" % (self.namespace, self.image), container)
             if m:
-                logger.info("STOPPING CONTAINER: %s", container)
-                cmd = ["docker", "kill", container]
+                logger.info("Stopping container: %s", container)
+                cmd = ["docker", "stop", container]
                 if self.dryrun:
                     logger.info("DRY-RUN: STOPPING CONTAINER %s", " ".join(cmd))
                 else:


### PR DESCRIPTION
In this PR, we are stopping containers a lot more gracefully than our previous code of `docker kill foobar`.

This change also relates to a bug where if a container is already stopped, Atomic App will error out when running `docker kill`.

Instead, we use `docker stop foobar` which has a 10 second timer for the container to stop peacefully, otherwise, it is killed. Container which are already stopped are ignored by the command.