### PR TITLE
native openshift: support nested Nulecule apps

### DIFF
--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -231,7 +231,9 @@ class OpenshiftClient(object):
             url,
             on_message=lambda ws, message: self._handle_exec_reply(ws, message, results, outfile))
 
-        ws.run_forever(sslopt={'cert_reqs': ssl.CERT_NONE})
+        ws.run_forever(sslopt={
+            'ca_certs': self.provider_ca,
+            'cert_reqs': ssl.CERT_REQUIRED if self.provider_tls_verify else ssl.CERT_NONE})
 
         if not outfile:
             return ''.join(results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ anymarkup
 lockfile
 jsonpointer
 requests
+websocket-client

--- a/tests/units/nulecule/test_nulecule.py
+++ b/tests/units/nulecule/test_nulecule.py
@@ -86,10 +86,10 @@ class TestNuleculeLoadComponents(unittest.TestCase):
 
         MockNuleculeComponent.assert_any_call(
             graph[0]['name'], n.basepath, 'somecontainer',
-            graph[0]['params'], None)
+            graph[0]['params'], None, {})
         MockNuleculeComponent.assert_any_call(
             graph[1]['name'], n.basepath, None,
-            graph[1].get('params'), graph[1].get('artifacts'))
+            graph[1].get('params'), graph[1].get('artifacts'), {})
 
 
 class TestNuleculeRender(unittest.TestCase):

--- a/tests/units/nulecule/test_nulecule_component.py
+++ b/tests/units/nulecule/test_nulecule_component.py
@@ -210,7 +210,7 @@ class TestNuleculeComponentLoadExternalApplication(unittest.TestCase):
             expected_external_app_path)
         mock_Nulecule.unpack.assert_called_once_with(
             nc.source, expected_external_app_path,
-            namespace=nc.namespace, dryrun=dryrun, update=update)
+            namespace=nc.namespace, config=None, dryrun=dryrun, update=update)
 
 
 class TestNuleculeComponentComponents(unittest.TestCase):


### PR DESCRIPTION
As discussed in #461, since Openshift does not allow access to host **docker** daemon to containers running inside pods. Currently, we use Docker to pull external Nulecule images and extract metadata from them.

This pull request implements unpacking a Nulecule image on Openshift using Openshift API calls.