### PR TITLE
cli: Add genanswers as a choice for --mode.

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -188,7 +188,7 @@ class CLI():
             "--mode",
             dest="mode",
             default=None,
-            choices=['install', 'run', 'stop'],
+            choices=['install', 'run', 'stop', 'genanswers'],
             help=('''
                  The mode Atomic App is run in. This option has the
                  effect of switching the 'verb' that was passed by the


### PR DESCRIPTION
One of the points of --mode was to be able to switch to the
"genanswers" mode from the atomic CLI. I left it out of the choices
of possible arguments to --mode from the CLI so it was broken. This
fixes that.