### PR TITLE
Allow providing default provider with Nulecule file.

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -41,6 +41,7 @@ DEFAULTNAME_KEY = "default"
 PROVIDER_KEY = "provider"
 NAMESPACE_KEY = "namespace"
 REQUIREMENTS_KEY = "requirements"
+DEFAULTPROVIDER_KEY = 'defaultprovider'
 
 # Nulecule spec terminology vs the function within /providers
 REQUIREMENT_FUNCTIONS = {
@@ -61,7 +62,6 @@ DEFAULT_CONTAINER_NAME = "atomic"
 DEFAULT_NAMESPACE = "default"
 DEFAULT_ANSWERS = {
     "general": {
-        "provider": DEFAULT_PROVIDER,
         "namespace": DEFAULT_NAMESPACE
     }
 }

--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -16,7 +16,10 @@ from atomicapp.constants import (APP_ENT_PATH,
                                  NAME_KEY,
                                  INHERIT_KEY,
                                  ARTIFACTS_KEY,
-                                 REQUIREMENTS_KEY)
+                                 REQUIREMENTS_KEY,
+                                 PROVIDER_KEY,
+                                 DEFAULTPROVIDER_KEY,
+                                 DEFAULT_PROVIDER)
 from atomicapp.utils import Utils
 from atomicapp.requirements import Requirements
 from atomicapp.nulecule.lib import NuleculeBase
@@ -188,6 +191,12 @@ class Nulecule(NuleculeBase):
         """
         super(Nulecule, self).load_config(
             config=config, ask=ask, skip_asking=skip_asking)
+
+        if not self.config[GLOBAL_CONF].get(PROVIDER_KEY):
+            self.config[GLOBAL_CONF][PROVIDER_KEY] = (
+                self.metadata.get(DEFAULTPROVIDER_KEY) or
+                DEFAULT_PROVIDER
+            )
         for component in self.components:
             # FIXME: Find a better way to expose config data to components.
             #        A component should not get access to all the variables,


### PR DESCRIPTION
This allows specifying a defaultprovider for a Nulecule app in the spec file in the metadata section:

```
metadata:
  name: Hello Apache App
  appversion: 0.0.1
  description: Atomic app for deploying a really basic Apache HTTP server
  defaultprovider: docker
...
```

In case you don't have ``provider`` specified in the ``[general]`` section of your ``answers.conf`` file, we first look for ``metadata.defaultprovider`` in Nulecule spec file. If no default provider is specified in
Nulecule metadata, we'll default to ``lib.constants.DEFAULT_PROVIDER`` for the provider, which is, ``kubernetes``.

Fixes #378