### PR TITLE
openshift provider: safer stop (undeploy)

### DIFF
--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -395,7 +395,9 @@ class OpenShiftProvider(Provider):
         logger.debug("Starting undeploy")
         delete_artifacts = []
         for kind, objects in self.openshift_artifacts.iteritems():
-            # Add DCs to beggining of list so they are deleted first.
+            # Add DCs to beginning of list so they are deleted first.
+            # Do DC first because if you do RC before DC then the DC
+            # will re-spawn the RC before the DC is deleted.
             if kind == "deploymentconfig":
                 delete_artifacts = objects + delete_artifacts
             else:

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -427,6 +427,9 @@ class Utils(object):
                 res = requests.put(url, json=data, verify=verify)
             elif method.lower() == "delete":
                 res = requests.delete(url, json=data, verify=verify)
+            elif method.lower() == "patch":
+                headers = {"Content-Type": "application/json-patch+json"}
+                res = requests.patch(url, json=data, verify=verify, headers=headers)
 
             status_code = res.status_code
             return_data = res.json()


### PR DESCRIPTION
Instead of finding and deleting related pods for RC, scale RC down to 0 replicas.

This should be much more cleaner then before.

This is how `kubectl` deletes RCs: https://github.com/kubernetes/kubernetes/blob/439d7a721e087f4015191fe7e2d0b9262abd2530/pkg/kubectl/stop.go#L127

This is how `oc` deletes DCs: https://github.com/openshift/origin/blob/bccc1d35c067d367009ee1406d5f2fc603b1ab5a/pkg/deploy/reaper/reaper.go#L33

TODO: 
- [x] make sure that DC is deleted before its RCs so it is not recreated [source](https://github.com/openshift/origin/blob/bccc1d35c067d367009ee1406d5f2fc603b1ab5a/pkg/deploy/reaper/reaper.go#L39)


