### PR TITLE
Allow users to provide answers file as url.

### DIFF
--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -90,6 +90,10 @@ class NuleculeManager(object):
         logger.debug("NuleculeManager init app_path: %s", self.app_path)
         logger.debug("NuleculeManager init    image: %s", self.image)
 
+        # Create the app_path if it doesn't exist yet
+        if not os.path.isdir(self.app_path):
+            os.makedirs(self.app_path)
+
         # Set where the main nulecule file should be
         self.main_file = os.path.join(self.app_path, MAIN_FILE)
 


### PR DESCRIPTION
This will allow one to specify a location of an answers file that can
be retrieved by Atomic App during deployment. A common case for this
would be if someone deploying the application wants to deploy many
times with a known good configuration where this configuration is
stored in source control or some other location accessed via a url.

This also may be one avenue for providing answers to applications
started via `oc new-app` in openshift.