### PR TITLE
Fail nicely if user does not provide artifact files within Nulecule.

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -372,6 +372,9 @@ class NuleculeComponent(NuleculeBase):
         if self._app:
             self._app.render(provider_key=provider_key, dryrun=dryrun)
             return
+        if self.artifacts is None:
+            raise NuleculeException(
+                "No artifacts specified in the Nulecule file")
         context = self.get_context()
         if provider_key and provider_key not in self.artifacts:
             raise NuleculeException(

--- a/tests/units/nulecule/test_nulecule_component.py
+++ b/tests/units/nulecule/test_nulecule_component.py
@@ -238,7 +238,7 @@ class TestNuleculeComponentRender(unittest.TestCase):
         provider_key = 'some-provider'
         dryrun = False
 
-        nc = NuleculeComponent(name='some-app', basepath='some/path')
+        nc = NuleculeComponent(name='some-app', basepath='some/path', artifacts="/foo/bar")
         nc._app = mock_nulecule
         nc.render(provider_key, dryrun)
 
@@ -258,6 +258,17 @@ class TestNuleculeComponentRender(unittest.TestCase):
         nc.artifacts = {'x': ['some-artifact']}
 
         self.assertRaises(NuleculeException, nc.render, provider_key, dryrun)
+
+    def test_render_for_local_app_with_missing_artifacts_from_nulecule(self):
+        """
+        Test rendering a Nulecule component with no artifacts provided in the
+        Nulecule file.
+        """
+        nc = NuleculeComponent(name='some-app', basepath='some/path')
+        nc.config = {}
+
+        with self.assertRaises(NuleculeException):
+            nc.render()
 
     @mock.patch('atomicapp.nulecule.base.NuleculeComponent.get_context')
     @mock.patch('atomicapp.nulecule.base.NuleculeComponent.'


### PR DESCRIPTION
Instead of erroring out:
```
2015-12-03 18:26:31,590 - atomicapp.cli.main - ERROR - argument of type 'NoneType' is not iterable
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/atomicapp-0.2.3-py2.7.egg/atomicapp/cli/main.py", line 74, in cli_run
    nm.run(**argdict)
  File "/usr/local/lib/python2.7/dist-packages/atomicapp-0.2.3-py2.7.egg/atomicapp/nulecule/main.py", line 187, in run
    self.nulecule.render(cli_provider, dryrun)
  File "/usr/local/lib/python2.7/dist-packages/atomicapp-0.2.3-py2.7.egg/atomicapp/nulecule/base.py", line 223, in render
    component.render(provider_key=provider_key, dryrun=dryrun)
  File "/usr/local/lib/python2.7/dist-packages/atomicapp-0.2.3-py2.7.egg/atomicapp/nulecule/base.py", line 348, in render
    if provider_key and provider_key not in self.artifacts:
TypeError: argument of type 'NoneType' is not iterable
```

It will error out with:
```
2016-01-26 11:30:27,838 - atomicapp.cli.main - ERROR - Unable to find artifact. Is the source path correct? 
```

Suggestions on wording is welcome.