### PR TITLE
marathon: do not convert types when parsing json artifact

### DIFF
--- a/atomicapp/providers/marathon.py
+++ b/atomicapp/providers/marathon.py
@@ -108,7 +108,9 @@ class Marathon(Provider):
             data = None
             with open(os.path.join(self.path, artifact), "r") as fp:
                 try:
-                    data = anymarkup.parse(fp)
+                    # env variables in marathon artifacts have to be string:string
+                    # force_types=None respects types from json file
+                    data = anymarkup.parse(fp, force_types=None)
                     logger.debug("Parsed artifact %s", data)
                     # every marathon app has to have id. 'id' key  is also used for showing messages
                     if "id" not in data.keys():


### PR DESCRIPTION
If marathon artifact has env variable that has number as value anymarkup converts this to int.
But Marathon api requires all env to be string:string.

`force_types=None` turns off type conversions. [1]

[1] https://github.com/bkabrda/anymarkup#notes-on-parsing-basic-types

