### PR TITLE
made `metadata` an optional argument in Nulecule file

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -39,7 +39,7 @@ class Nulecule(NuleculeBase):
     componenents, but does not have access to its parent's scope.
     """
 
-    def __init__(self, id, specversion, metadata, graph, basepath,
+    def __init__(self, id, specversion, graph, basepath, metadata=None,
                  requirements=None, params=None, config=None,
                  namespace=GLOBAL_CONF):
         """
@@ -48,9 +48,9 @@ class Nulecule(NuleculeBase):
         Args:
             id (str): Nulecule application ID
             specversion (str): Nulecule spec version
-            metadata (dict): Nulecule metadata
             graph (list): Nulecule graph of components
             basepath (str): Basepath for Nulecule application
+            metadata (dict): Nulecule metadata
             requirements (dict): Requirements for the Nulecule application
             params (list): List of params for the Nulecule application
             config (dict): Config data for the Nulecule application
@@ -62,7 +62,7 @@ class Nulecule(NuleculeBase):
         super(Nulecule, self).__init__(basepath, params, namespace)
         self.id = id
         self.specversion = specversion
-        self.metadata = metadata
+        self.metadata = metadata or {}
         self.graph = graph
         self.requirements = requirements
         self.config = config or {}

--- a/tests/units/nulecule/test_nulecule.py
+++ b/tests/units/nulecule/test_nulecule.py
@@ -13,7 +13,7 @@ class TestNuleculeRun(unittest.TestCase):
         mock_component_1 = mock.Mock()
         mock_component_2 = mock.Mock()
 
-        n = Nulecule('some-id', '0.0.2', {}, [{}], 'some/path')
+        n = Nulecule('some-id', '0.0.2', [{}], 'some/path', {})
         n.components = [mock_component_1, mock_component_2]
         n.run(provider)
 
@@ -134,7 +134,7 @@ class TestNuleculeLoadComponents(unittest.TestCase):
             }
         ]
 
-        n = Nulecule('some-id', '0.0.2', {}, graph, 'some/path')
+        n = Nulecule('some-id', '0.0.2', graph, 'some/path', {})
         n.load_components()
 
         MockNuleculeComponent.assert_any_call(


### PR DESCRIPTION
Atomicapp would fail if `metadata` was not specified in Nulecule file.
While according to Nulecule specification `metadata` is an optional
argument. This would fail because while creating `Nulecule` object
`metadata` was positional argument. So fixed this by making it a keyword
argument. Also tests have been modified accordingly.

This closes issue #502