### PR TITLE
Change order of getting context

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -380,14 +380,15 @@ class NuleculeComponent(NuleculeBase):
         if self._app:
             self._app.render(provider_key=provider_key, dryrun=dryrun)
             return
+
         if self.artifacts is None:
             raise NuleculeException(
                 "No artifacts specified in the Nulecule file")
-        context = self.get_context()
         if provider_key and provider_key not in self.artifacts:
             raise NuleculeException(
                 "Data for provider \"%s\" are not part of this app"
                 % provider_key)
+        context = self.get_context()
         for provider in self.artifacts:
             if provider_key and provider != provider_key:
                 continue


### PR DESCRIPTION
Small fix. Just nitpicky on getting context, should grab it before `context` is actually called.