### PR TITLE
Add option in makefile to copy over manpage during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 all:
 	python -m pytest -vv
 
-install:
+docs:
+	install -d /usr/share/man/man1
+	install -m 644 docs/man/atomicapp.1 /usr/share/man/man1
+
+install: docs
 	python setup.py install
 
 test:


### PR DESCRIPTION
Relies on #516. Please merge that first :)

Adds a manpage to atomicapp, THANKS @ingvagabund !!!