### PR TITLE
Makes Makefile faster using .PHONY && add default python location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Travis CI checks for atomicapp
 
 language: python
+sudo: required
 
 python:
   - "2.7"
@@ -9,18 +10,16 @@ notifications:
   irc: "chat.freenode.net#nulecule"
 
 before_install:
-  - pip install pytest-cov coveralls --use-mirrors
-  - pip install pep8 --use-mirrors
-  - pip install flake8 --use-mirrors 
+  - sudo pip install pytest-cov coveralls pep8 flake8
 
 install:
-  - make install
+  - sudo make install
 
 before_script:
-  - make syntax-check
+  - sudo make syntax-check
 
 script:
-  - make test
+  - sudo make test
 
 after_success:
-  - coveralls
+  - sudo coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,29 @@
+# Default dir locations
+PYTHON ?= /usr/bin/python
+
+# Methods
+.PHONY: all
 all:
-	python -m pytest -vv
+	$(PYTHON) -m pytest -vv
 
+.PHONY: install
 install:
-	python setup.py install
+	$(PYTHON) setup.py install
 
+.PHONY: test
 test:
 	pip install -qr requirements.txt
 	pip install -qr test-requirements.txt
-	python -m pytest -vv
+	$(PYTHON) -m pytest -vv
 
+.PHONY: image
 image:
 	docker build -t $(tag) .
 
+.PHONY: syntax-check
 syntax-check:
 	flake8 atomicapp
 
+.PHONY: clean
 clean:
-	python setup.py clean --all
+	$(PYTHON) setup.py clean --all

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-# Default dir locations
+# This can be overriden (for eg):
+# make install PYTHON=/usr/bin/python2.7
 PYTHON ?= /usr/bin/python
+DOCKER ?= /usr/bin/docker
 
-# Methods
 .PHONY: all
 all:
 	$(PYTHON) -m pytest -vv
@@ -18,7 +19,7 @@ test:
 
 .PHONY: image
 image:
-	docker build -t $(tag) .
+	$(DOCKER) build -t $(tag) .
 
 .PHONY: syntax-check
 syntax-check:


### PR DESCRIPTION
See https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html as well as the improvements on Atomic CLI's Makefile https://github.com/projectatomic/atomic/blob/master/Makefile

We use .PHONY to avoid any conflicting names as well as speed up installation.

A default dir for Python has also been added for any future changes (ex. if we want to build with python3 we can do PYTHON=/usr/bin/python3 sudo make install)