### PR TITLE
providerconfig: support someone specifying a relative path

### DIFF
--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -72,8 +72,9 @@ class Provider(object):
         """
         if PROVIDER_CONFIG_KEY in self.config:
             self.config_file = self.config[PROVIDER_CONFIG_KEY]
-            if self.container:
-                self.config_file = os.path.join(Utils.getRoot(), self.config_file.lstrip("/"))
+            if os.path.isabs(self.config_file):
+                self.config_file = os.path.join(Utils.getRoot(),
+                                                self.config_file.lstrip('/'))
         else:
             logger.warning("Configuration option '%s' not found" % PROVIDER_CONFIG_KEY)
 


### PR DESCRIPTION
This will allow someone to support a relative path for the
providerconfig. The providerconfig must be under the users
current working directory and can't be outside of it.