### PR TITLE
nulecule: error if no artifacts in spec for inherited provider

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -400,6 +400,13 @@ class NuleculeComponent(NuleculeBase):
         """
         artifact_paths = []
         artifacts = self.artifacts.get(provider_key)
+
+        # If there are no artifacts for the requested provider then error
+        # This can happen for incorrectly named inherited provider (#435)
+        if artifacts is None:
+            raise NuleculeException(
+                "No artifacts for provider {}".format(provider_key))
+
         for artifact in artifacts:
             # Convert dict if the Nulecule file references "resource"
             if isinstance(artifact, dict) and artifact.get(RESOURCE_KEY):


### PR DESCRIPTION
If the Nulecule file for an app specifies a provider to inherit from
but the specfile doesn't have any entry for that provider, then error.

Fixes #435