### PR TITLE
Handle docker pull exception, improve #441, fix #568

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -37,7 +37,7 @@ from atomicapp.constants import (__ATOMICAPPVERSION__,
                                  LOGGER_DEFAULT,
                                  PROVIDERS)
 from atomicapp.nulecule import NuleculeManager
-from atomicapp.nulecule.exceptions import NuleculeException
+from atomicapp.nulecule.exceptions import NuleculeException, DockerException
 from atomicapp.utils import Utils
 
 logger = logging.getLogger(LOGGER_DEFAULT)
@@ -106,6 +106,9 @@ def cli_run(args):
         else:
             print_app_location(nm.app_path)
         sys.exit(0)
+    except DockerException as e:
+        logger.error(e)
+        sys.exit(1)
     except NuleculeException as e:
         logger.error(e)
         sys.exit(1)

--- a/atomicapp/nulecule/container.py
+++ b/atomicapp/nulecule/container.py
@@ -8,7 +8,7 @@ from atomicapp.constants import (APP_ENT_PATH,
                                  LOGGER_DEFAULT,
                                  MAIN_FILE)
 from atomicapp.utils import Utils
-from atomicapp.nulecule.exceptions import NuleculeException
+from atomicapp.nulecule.exceptions import NuleculeException, DockerException
 
 cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
 logger = logging.getLogger(LOGGER_DEFAULT)
@@ -60,7 +60,7 @@ class DockerHandler(object):
         if self.dryrun:
             logger.info("DRY-RUN: %s", pull_cmd)
         elif subprocess.call(pull_cmd) != 0:
-            raise Exception("Could not pull Docker image %s" % image)
+            raise DockerException("Could not pull Docker image %s" % image)
 
         cockpit_logger.info('Skipping pulling Docker image: %s' % image)
 

--- a/atomicapp/nulecule/exceptions.py
+++ b/atomicapp/nulecule/exceptions.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
+class DockerException(Exception):
+    pass
+
+
 class NuleculeException(Exception):
     pass


### PR DESCRIPTION
Create `DockerException` to handle a specific exception instead of the generic (`raise Exception`) which prints out the traceback too.