### PR TITLE
Implement LoggerAdapter to provide extended paths in the output. Improve #571

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -21,7 +21,6 @@ import os
 import sys
 
 import argparse
-import logging
 from lockfile import LockFile
 from lockfile import AlreadyLocked
 
@@ -34,13 +33,13 @@ from atomicapp.constants import (__ATOMICAPPVERSION__,
                                  CACHE_DIR,
                                  HOST_DIR,
                                  LOCK_FILE,
-                                 LOGGER_DEFAULT,
                                  PROVIDERS)
 from atomicapp.nulecule import NuleculeManager
 from atomicapp.nulecule.exceptions import NuleculeException
 from atomicapp.utils import Utils
 
-logger = logging.getLogger(LOGGER_DEFAULT)
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 def print_app_location(app_path):

--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -11,7 +11,6 @@ from atomicapp.constants import (APP_ENT_PATH,
                                  EXTERNAL_APP_DIR,
                                  GLOBAL_CONF,
                                  LOGGER_COCKPIT,
-                                 LOGGER_DEFAULT,
                                  MAIN_FILE,
                                  RESOURCE_KEY,
                                  PARAMS_KEY,
@@ -26,11 +25,13 @@ from atomicapp.nulecule.lib import NuleculeBase
 from atomicapp.nulecule.container import DockerHandler
 from atomicapp.nulecule.exceptions import NuleculeException
 from atomicapp.providers.openshift import OpenShiftProvider
-
+from atomicapp.applogging import Logging
 from jsonpointer import resolve_pointer, set_pointer, JsonPointerException
 
 cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
-logger = logging.getLogger(LOGGER_DEFAULT)
+
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class Nulecule(NuleculeBase):

--- a/atomicapp/nulecule/container.py
+++ b/atomicapp/nulecule/container.py
@@ -3,15 +3,17 @@ import subprocess
 import uuid
 import logging
 
+from atomicapp.applogging import Logging
 from atomicapp.constants import (APP_ENT_PATH,
                                  LOGGER_COCKPIT,
-                                 LOGGER_DEFAULT,
                                  MAIN_FILE)
 from atomicapp.utils import Utils
 from atomicapp.nulecule.exceptions import NuleculeException
 
 cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
-logger = logging.getLogger(LOGGER_DEFAULT)
+
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class DockerHandler(object):

--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -8,6 +8,7 @@ import tempfile
 import urlparse
 import urllib
 
+from atomicapp.applogging import Logging
 from atomicapp.constants import (GLOBAL_CONF,
                                  ANSWERS_FILE_SAMPLE_FORMAT,
                                  ANSWERS_FILE,
@@ -15,7 +16,6 @@ from atomicapp.constants import (GLOBAL_CONF,
                                  ANSWERS_RUNTIME_FILE,
                                  DEFAULT_ANSWERS,
                                  LOGGER_COCKPIT,
-                                 LOGGER_DEFAULT,
                                  MAIN_FILE,
                                  PROVIDER_KEY)
 from atomicapp.nulecule.base import Nulecule
@@ -23,7 +23,8 @@ from atomicapp.nulecule.exceptions import NuleculeException
 from atomicapp.utils import Utils
 
 cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
-logger = logging.getLogger(LOGGER_DEFAULT)
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class NuleculeManager(object):

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -24,18 +24,17 @@ import os
 
 import imp
 
-import logging
+from atomicapp.applogging import Logging
 from utils import Utils
 from constants import (HOST_DIR,
-                       LOGGER_DEFAULT,
                        PROVIDER_CONFIG_KEY)
 
-logger = logging.getLogger(LOGGER_DEFAULT)
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class Provider(object):
     key = None
-
     config = None
     path = None
     dryrun = None

--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -20,14 +20,15 @@
 import os
 import subprocess
 import re
-import logging
+
+from atomicapp.applogging import Logging
 from atomicapp.constants import (DEFAULT_CONTAINER_NAME,
-                                 DEFAULT_NAMESPACE,
-                                 LOGGER_DEFAULT)
+                                 DEFAULT_NAMESPACE,)
 from atomicapp.plugin import Provider, ProviderFailedException
 from atomicapp.utils import Utils
 
-logger = logging.getLogger(LOGGER_DEFAULT)
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class DockerProvider(Provider):

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -22,13 +22,14 @@ import logging
 import os
 from string import Template
 
-from atomicapp.constants import (LOGGER_COCKPIT,
-                                 LOGGER_DEFAULT)
+from atomicapp.constants import (LOGGER_COCKPIT)
 from atomicapp.plugin import Provider, ProviderFailedException
 from atomicapp.utils import Utils
+from atomicapp.applogging import Logging
 
 cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
-logger = logging.getLogger(LOGGER_DEFAULT)
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class KubernetesProvider(Provider):

--- a/atomicapp/providers/marathon.py
+++ b/atomicapp/providers/marathon.py
@@ -21,14 +21,15 @@ import anymarkup
 import urlparse
 import logging
 import os
-from atomicapp.constants import (LOGGER_COCKPIT,
-                                 LOGGER_DEFAULT)
+from atomicapp.constants import (LOGGER_COCKPIT)
 from atomicapp.plugin import Provider, ProviderFailedException
 from atomicapp.utils import Utils
 from atomicapp.constants import PROVIDER_API_KEY
+from atomicapp.applogging import Logging
 
 cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
-logger = logging.getLogger(LOGGER_DEFAULT)
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class Marathon(Provider):

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -29,18 +29,18 @@ import websocket
 
 from atomicapp.utils import Utils
 from atomicapp.plugin import Provider, ProviderFailedException
+from atomicapp.applogging import Logging
 from atomicapp.constants import (ACCESS_TOKEN_KEY,
                                  ANSWERS_FILE,
                                  DEFAULT_NAMESPACE,
-                                 LOGGER_DEFAULT,
                                  NAMESPACE_KEY,
                                  PROVIDER_API_KEY,
                                  PROVIDER_TLS_VERIFY_KEY,
                                  PROVIDER_CA_KEY)
 from requests.exceptions import SSLError
-import logging
-logger = logging.getLogger(LOGGER_DEFAULT)
 
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 # If running in an openshift POD via `oc new-app`, the ca file is here
 OPENSHIFT_POD_CA_FILE = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -31,19 +31,21 @@ from distutils.spawn import find_executable
 
 import logging
 
+from atomicapp.applogging import Logging
+
 from subprocess import Popen, PIPE
 from constants import (APP_ENT_PATH,
                        CACHE_DIR,
                        EXTERNAL_APP_DIR,
                        HOST_DIR,
                        LOGGER_COCKPIT,
-                       LOGGER_DEFAULT,
                        WORKDIR)
 
 __all__ = ('Utils')
 
 cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
-logger = logging.getLogger(LOGGER_DEFAULT)
+# assign the logger instance from applogging.py to use here
+logger = Logging.global_logger(__file__)
 
 
 class AtomicAppUtilsException(Exception):


### PR DESCRIPTION
![screenshot from 2016-02-24 22-23-17](https://cloud.githubusercontent.com/assets/9133660/13293364/65b3459e-db45-11e5-8487-8dc6fac6f95e.png)


A logger adapter has been created in applogging.py, and the logging instance created by it is the same which is being used by other files, unlike before when each file created their own instance.

This is done so that additional contextual output can be outputted in the logging messages, which is currently only the filename which is making the logging calls.

In the other files, only one import (`from atomicapp.applogging import Logging`) and one initialization (`logger = Logging.global_logger(__file__)`), and it's done.

The code is poor, but it would be great if I could get some feedback on the approach and where can it be improved.

Also, I have not touched the cockpit logger and not included the check for --verbose, will do once this is reviewed.

P.S. Sorry for the changes around imports, the IDE rearranged them according to PEP8.