### PR TITLE
Install requirements before make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ install:
 	python setup.py install
 
 test:
+	pip install -qr requirements.txt
+	pip install -qr test-requirements.txt
 	python -m pytest -vv
 
 image:


### PR DESCRIPTION
In a clean environment where nothing is installed and if I run `make test` then the required modules should be installed first. So before `make test` added pip install from requirements.txt and test-requirements.txt.