### PR TITLE
Error cleanly on missing Nulecule or invalid formatted Nulecule

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -133,7 +133,8 @@ class Nulecule(NuleculeBase):
         nulecule_path = os.path.join(src, MAIN_FILE)
 
         if os.path.exists(nulecule_path):
-            nulecule_data = open(nulecule_path, 'r').read()
+            with open(nulecule_path, 'r') as f:
+                nulecule_data = f.read()
         else:
             raise NuleculeException("No Nulecule file exists in directory: %s" % src)
 
@@ -148,9 +149,14 @@ class Nulecule(NuleculeBase):
         except (yaml.parser.ParserError, AnyMarkupError), e:
             line = re.search('line (\d+)', str(e)).group(1)
             column = re.search('column (\d+)', str(e)).group(1)
-            data = nulecule_data.splitlines()[int(line)]
-            raise NuleculeException("Failure parsing Nulecule file. Validation error on line %s, column %s:\n%s"
-                                    % (line, column, data))
+
+            output = ""
+            for i, l in enumerate(nulecule_data.splitlines()):
+                if (i == int(line) - 1) or (i == int(line)) or (i == int(line) + 1):
+                    output += "%s %s\n" % (str(i), str(l))
+
+            raise NuleculeException("Failure parsing %s file. Validation error on line %s, column %s:\n%s"
+                                    % (nulecule_path, line, column, output))
 
         nulecule = Nulecule(config=config, basepath=src,
                             namespace=namespace, **nulecule_data)

--- a/tests/units/nulecule/invalid_nulecule/Nulecule
+++ b/tests/units/nulecule/invalid_nulecule/Nulecule
@@ -1,0 +1,37 @@
+{
+    "specversion": "0.0.2",
+    "id": "helloapache-app",
+    "metadata": {
+        "name": "Hello Apache App",
+        "appversion": "0.0.1",
+        "description": "Atomic app for deploying a really basic Apache HTTP server"
+    },
+    "graph": [
+        {
+            "name": "helloapache-app",
+            "params": [[
+                {
+                    "name": "image",
+                    "description": "The webserver image",
+                    "default": "centos/httpd"
+                },
+                {
+                    "name": "hostport",
+                    "description": "The host TCP port as the external endpoint",
+                    "default": 80
+                }
+            ],
+            "artifacts": {
+                "docker": [
+                    "file://artifacts/docker/hello-apache-pod_run"
+                ],
+                "kubernetes": [
+                    "file://artifacts/kubernetes/hello-apache-pod.json"
+                ],
+                "marathon": [
+                    "file://artifacts/marathon/helloapache.json"
+                ]
+            }
+        }
+    ]
+}

--- a/tests/units/nulecule/test_nulecule.py
+++ b/tests/units/nulecule/test_nulecule.py
@@ -1,6 +1,9 @@
 import mock
 import unittest
+import pytest
+import os
 from atomicapp.nulecule.base import Nulecule
+from atomicapp.nulecule.exceptions import NuleculeException
 
 
 class TestNuleculeRun(unittest.TestCase):
@@ -163,3 +166,16 @@ class TestNuleculeRender(unittest.TestCase):
             provider_key=provider_key, dryrun=dryrun)
         mock_component_2.render.assert_called_once_with(
             provider_key=provider_key, dryrun=dryrun)
+
+
+class TestLoadNuleculeParsing(unittest.TestCase):
+
+    def test_missing_nulecule(self):
+        n = Nulecule('some-id', '0.0.2', {}, [], 'some/path')
+        with pytest.raises(NuleculeException):
+            n.load_from_path(src='foo/bar')
+
+    def test_invalid_nulecule_format(self):
+        n = Nulecule('some-id', '0.0.2', {}, [], 'some/path')
+        with pytest.raises(NuleculeException):
+            n.load_from_path(src=os.path.dirname(__file__) + '/invalid_nulecule/')


### PR DESCRIPTION
This commit checks to see if the actual Nulecule exists before loading. If
the Nulecule file is missing it will cleanly error out.

If a Nulecule is wrongly formatted, atomicapp will exit cleanly with a line
number, column and the output of the invalid line.

ex.
``` 
2016-03-04 13:03:59,617 - [ERROR] - main.py - Failure parsing Nulecule
file. Validation error on line 12, column 23:
            {
```

Fixes issues:
#581 
#553