### PR TITLE
Switch from subprocess to Utils.run_cmd(cmd)

### DIFF
--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -103,7 +103,7 @@ class DockerProvider(Provider):
             if self.dryrun:
                 logger.info("DRY-RUN: %s", " ".join(cmd))
             else:
-                subprocess.check_call(cmd)
+                Utils.run_cmd(cmd)
 
     def stop(self):
         logger.info("Undeploying to provider: Docker")
@@ -140,4 +140,4 @@ class DockerProvider(Provider):
                 if self.dryrun:
                     logger.info("DRY-RUN: STOPPING CONTAINER %s", " ".join(cmd))
                 else:
-                    subprocess.check_call(cmd)
+                    Utils.run_cmd(cmd)


### PR DESCRIPTION
Similar to the Kubernetes provider, use run_cmd for more stdout and
stderr approach for debugging.

First part of a fix for:

https://github.com/projectatomic/atomicapp/issues/590

Second part will be a different output (show the error code!) :)