### PR TITLE
Remove extra newline on main.py

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -47,7 +47,7 @@ def print_app_location(app_path):
     if app_path.startswith(HOST_DIR):
         app_path = app_path[len(HOST_DIR):]
     print("\nYour application resides in %s" % app_path)
-    print("Please use this directory for managing your application\n")
+    print("Please use this directory for managing your application")
 
 
 def cli_genanswers(args):


### PR DESCRIPTION
I get two newlines when using `atomicapp`. I think it should just be
one!