### PR TITLE
Use logger for print output in main.py

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -46,8 +46,8 @@ logger = logging.getLogger(LOGGER_DEFAULT)
 def print_app_location(app_path):
     if app_path.startswith(HOST_DIR):
         app_path = app_path[len(HOST_DIR):]
-    print("\nYour application resides in %s" % app_path)
-    print("Please use this directory for managing your application\n")
+    logger.info("Your application resides in %s" % app_path)
+    logger.info("Please use this directory for managing your application")
 
 
 def cli_genanswers(args):


### PR DESCRIPTION
Instead of print, use logger.info(). Using print creates uneeded
logging for cockpit and makes the overall logging more cleaner.

Although may need quick discussion since it's less obvious to the user
when this is outputted (before it was a new-line print with no [INFO]
beside it). Maybe output via logger but without the data / info /
cli.mainpy information?)