### PR TITLE
Fix #597 - Make test fails with LockFailed: failed to create /run/lock/

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -33,7 +33,6 @@ from atomicapp.constants import (__ATOMICAPPVERSION__,
                                  APP_ENT_PATH,
                                  CACHE_DIR,
                                  HOST_DIR,
-                                 LOCK_FILE,
                                  LOGGER_DEFAULT,
                                  PROVIDERS)
 from atomicapp.nulecule import NuleculeManager

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -448,7 +448,7 @@ class CLI():
             if hasattr(args, item) and getattr(args, item) is not None:
                 args.cli_answers[item] = getattr(args, item)
 
-        lock = LockFile(os.path.join(Utils.getRoot(), LOCK_FILE))
+        lock = LockFile(Utils.getLockFile())
         try:
             lock.acquire(timeout=-1)
             args.func(args)

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -53,7 +53,9 @@ ANSWERS_RUNTIME_FILE = "answers.conf.gen"
 ANSWERS_FILE_SAMPLE = "answers.conf.sample"
 ANSWERS_FILE_SAMPLE_FORMAT = 'ini'
 WORKDIR = ".workdir"
-LOCK_FILE = "/run/lock/atomicapp.lock"
+LOCK_FOLDER = "/run/lock/"
+LOCK_FILE = "atomicapp.lock"
+CURRENT_TEMP_FOLDER = ".tmp"
 
 LOGGER_DEFAULT = "atomicapp"
 LOGGER_COCKPIT = "cockpit"

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -28,6 +28,8 @@ import anymarkup
 import uuid
 import requests
 from distutils.spawn import find_executable
+import constants
+import errno
 
 import logging
 
@@ -351,6 +353,31 @@ class Utils(object):
             return HOST_DIR
         else:
             return "/"
+
+    @staticmethod
+    def getLockFolder():
+        if os.access(constants.LOCK_FOLDER, os.W_OK):
+            return constants.LOCK_FOLDER
+        else:
+            # remove leading slash and then join ( see os.path.join() for details )
+            return os.path.join(constants.CURRENT_TEMP_FOLDER,
+                                str.lstrip(constants.LOCK_FOLDER, "/"))
+
+    @staticmethod
+    def getLockFile():
+        lockfolder = Utils.getLockFolder()
+        lockfile = os.path.join(lockfolder, constants.LOCK_FILE)
+        if lockfile.startswith(constants.CURRENT_TEMP_FOLDER):  # temporary path
+            # ensure that lock folder exists
+            try:
+                os.makedirs(lockfolder)
+            except OSError as exc:
+                if exc.errno == errno.EEXIST and os.path.isdir(lockfolder):
+                    pass
+
+            return lockfile
+        else:
+            return os.path.join(Utils.getRoot(), lockfile)
 
     # generates a unique 12 character UUID
     @staticmethod


### PR DESCRIPTION
When running tests via `make test`, many test fail because current user doesn't have enough permissions for `/run/lock` folder. This patch configures `.tmp` folder in current directory to be used in such situation.

```
$ ls -lda .tmp/run/lock/
drwxrwxr-x. 2 saleem saleem 4096 Mar  7 19:46 .tmp/run/lock/
```

Made changes to make this work. All tests pass.