### PR TITLE
Multiple problems with issuestats.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ For a detailed description of all providers available see [docs/providers.md](do
 [![Code Health](https://landscape.io/github/projectatomic/atomicapp/master/landscape.svg?style=flat)](https://landscape.io/github/projectatomic/atomicapp/master)
 [![Build Status](https://travis-ci.org/projectatomic/atomicapp.svg?branch=master)](https://travis-ci.org/projectatomic/atomicapp)
 [![Coverage Status](https://coveralls.io/repos/projectatomic/atomicapp/badge.svg?branch=master&service=github)](https://coveralls.io/github/projectatomic/atomicapp?branch=master)
-[![Issue Stats](http://issuestats.com/github/projectatomic/atomicapp/badge/pr)](http://issuestats.com/github/projectatomic/atomicapp)
-[![Issue Stats](http://issuestats.com/github/projectatomic/atomicapp/badge/issue)](http://issuestats.com/github/projectatomic/atomicapp)
 
 First of all, awesome! We have [a development guide to help you get started!](CONTRIBUTING.md)
 


### PR DESCRIPTION
For the past two weeks, issuestats have been having multiple problems
with uptime as well as API calls.

(even right now at this moment: 03/07/2016 18:13 UTC each page load is
more than 3000ms.

Do we still want these on our README?