### PR TITLE
Typo in providers docs

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # Providers
 
-This chapter includes linkes to documentation on how to use and configure the
+This chapter includes links to documentation on how to use and configure the
 providers that are supported by Atomic App. The linked documentation
 will give you a short overview of all available providers and how
 to use them.


### PR DESCRIPTION
links was spelled as linkes, fixed that.