### PR TITLE
Inform user when provider not specified

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -200,6 +200,8 @@ class Nulecule(NuleculeBase):
             config=config, ask=ask, skip_asking=skip_asking)
         if self.namespace == GLOBAL_CONF and self.config[GLOBAL_CONF].get('provider') is None:
             self.config[GLOBAL_CONF]['provider'] = DEFAULT_PROVIDER
+            logger.info("Provider not specified, using default provider - {}".
+                        format(DEFAULT_PROVIDER))
         for component in self.components:
             # FIXME: Find a better way to expose config data to components.
             #        A component should not get access to all the variables,


### PR DESCRIPTION
When user has not specified the provider, Atomic App defaults to `kubernetes` as provider. This should be informed to user, in the form of log as INFO. This can help in issue #589.