### PR TITLE
Instruction to skip travis CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,8 @@ Before you submit your pull request consider the following guidelines:
 
 That's it! Thank you for your contribution!
 
+**NOTE**: When submitting a documentation PR, you can skip the travis ci by adding `[ci skip]` to your commit message.
+
 ### Merge Rules
 
 * Include unit or integration tests for the capability you have implemented


### PR DESCRIPTION
Added a NOTE in submitting pull request section, specifying for documentation PR how to skip travis CI build.

Fixes #605.