### PR TITLE
Change from ReadWrite to ReadWriteOnce in persistent storage tests

### DIFF
--- a/tests/units/persistent_storage/test_examples/ps-helloapache/Nulecule
+++ b/tests/units/persistent_storage/test_examples/ps-helloapache/Nulecule
@@ -23,9 +23,9 @@ graph:
     requirements:
       - persistentVolume:
           name: "var-lib-mongodb-data"
-          accessMode: "ReadWrite"
+          accessMode: "ReadWriteOnce"
           size: 4
       - persistentVolume:
           name: "var-log-mongodb"
-          accessMode: "ReadWrite"
+          accessMode: "ReadWriteOnce"
           size: 4

--- a/tests/units/persistent_storage/test_ps.py
+++ b/tests/units/persistent_storage/test_ps.py
@@ -10,8 +10,8 @@ class TestPersistentStorage(unittest.TestCase):
     def setUp(self):
         config = {'helloapache-app': {'image': 'centos/httpd', 'hostport': 80},
                   'general': {'namespace': 'default', 'provider': 'kubernetes'}}
-        graph = [{'persistentVolume': {'accessMode': 'ReadWrite', 'name': 'var-lib-mongodb-data', 'size': 4}},
-                 {'persistentVolume': {'accessMode': 'ReadWrite', 'name': 'var-log-mongodb', 'size': 4}}]
+        graph = [{'persistentVolume': {'accessMode': 'ReadWriteOnce', 'name': 'var-lib-mongodb-data', 'size': 4}},
+                 {'persistentVolume': {'accessMode': 'ReadWriteOnce', 'name': 'var-log-mongodb', 'size': 4}}]
         self.tmpdir = tempfile.mkdtemp(prefix="atomicapp-test", dir="/tmp")
         self.test = Requirements(
             config=config, basepath=self.tmpdir, graph=graph, provider="kubernetes", dryrun=True)


### PR DESCRIPTION
In 1.0.0 of Kubernetes it is no longer ReadWrite but now ReadWriteOnce.

http://kubernetes.io/v1.1/docs/user-guide/persistent-volumes.html

This modifies the tests to ReadWriteOnce instead of ReadWrite.