### PR TITLE
Add Persistent Storage validation on ReadWriteOnce, etc.

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -75,3 +75,6 @@ ACCESS_TOKEN_KEY = "accesstoken"
 PROVIDER_CONFIG_KEY = "providerconfig"
 PROVIDER_TLS_VERIFY_KEY = "providertlsverify"
 PROVIDER_CA_KEY = "providercafile"
+
+# Persistent Storage Formats
+PERSISTENT_STORAGE_FORMAT = ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -23,7 +23,8 @@ import os
 from string import Template
 
 from atomicapp.constants import (LOGGER_COCKPIT,
-                                 LOGGER_DEFAULT)
+                                 LOGGER_DEFAULT,
+                                 PERSISTENT_STORAGE_FORMAT)
 from atomicapp.plugin import Provider, ProviderFailedException
 from atomicapp.utils import Utils
 
@@ -216,6 +217,12 @@ class KubernetesProvider(Provider):
         """
 
         logger.debug("Persistent storage enabled! Running action: %s" % action)
+
+        if graph["accessMode"] not in PERSISTENT_STORAGE_FORMAT:
+            raise ProviderFailedException("{} is an invalid storage format "
+                                          "(choose from {})"
+                                          .format(graph["accessMode"],
+                                                  ', '.join(PERSISTENT_STORAGE_FORMAT)))
 
         if action not in ['run']:
             logger.warning(


### PR DESCRIPTION
This commit add validation for the Kubernetes provider for persistent
storage. We check against a list of method (ReadWriteOnce,
ReadWriteMany and ReadOnlyMany) before proceeding.

See: http://kubernetes.io/v1.1/docs/user-guide/persistent-volumes.html