### PR TITLE
Change asking format

### DIFF
--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -278,12 +278,12 @@ class Utils(object):
             repeat = False
             if "default" in info:
                 value = raw_input(
-                    "%s (%s, default: %s): " % (what, desc, info["default"]))
+                    "==> %s (%s, default: %s): " % (what, desc, info["default"]))
                 if len(value) == 0:
                     value = info["default"]
             else:
                 try:
-                    value = raw_input("%s (%s): " % (what, desc))
+                    value = raw_input("==> %s (%s): " % (what, desc))
                 except EOFError:
                     raise
 


### PR DESCRIPTION
This commit changes the asking format to as follows:

```
▶ sudo atomicapp run test
2016-03-10 16:28:42,538 - [INFO] - main.py - Action/Mode Selected is:
run
2016-03-10 16:28:42,538 - [INFO] - base.py - Unpacking image: test to
/var/lib/atomicapp/test-a695e48e14b7
2016-03-10 16:28:43,048 - [INFO] - container.py - Skipping pulling
Docker image: test
2016-03-10 16:28:43,048 - [INFO] - container.py - Extracting nulecule
data from image: test to /var/lib/atomicapp/test-a695e48e14b7
07265a212c555225a3774fccfe62a24bc50ed8342a6f01739027e507035f640e
2016-03-10 16:28:43,254 - [INFO] - base.py - Provider not specified,
using default provider - kubernetes
==> mongodb_admin_password (MongoDB Administrator password)
<== foo
==> mongodb_database (MongoDB Database name)
<== bar
==> mongodb_password (Password for the $mongodb_user account)
<==
```

Making it more clear to the user what is being asked / required. This is
similar to Vagrant's formatting.