### PR TITLE
Clean up logging output (convert to epoch time, remove time on normal output)

### DIFF
--- a/atomicapp/applogging.py
+++ b/atomicapp/applogging.py
@@ -121,7 +121,7 @@ class Logging:
         if logging_level == logging.DEBUG:
             formatstr = '%(asctime)s - [%(levelname)s] - %(longerfilename)s - %(message)s'
         else:
-            formatstr = '%(asctime)s - [%(levelname)s] - %(filename)s - %(message)s'
+            formatstr = '[%(levelname)s] - %(filename)s - %(message)s'
 
         # Get the loggers and clear out the handlers (allows this function
         # to be ran more than once)

--- a/atomicapp/applogging.py
+++ b/atomicapp/applogging.py
@@ -123,6 +123,10 @@ class Logging:
         else:
             formatstr = '[%(levelname)s] - %(filename)s - %(message)s'
 
+        # Set a tuple of options that will be passed to the formatter. The %s
+        # will tell the logging library to use seconds since epoch for time stamps
+        formattup = (formatstr, "%s")
+
         # Get the loggers and clear out the handlers (allows this function
         # to be ran more than once)
         logger = logging.getLogger(LOGGER_DEFAULT)
@@ -154,7 +158,7 @@ class Logging:
 
             # configure logger for basic no color printing to stdout
             handler = logging.StreamHandler(stream=sys.stdout)
-            formatter = customOutputFormatter(formatstr)
+            formatter = customOutputFormatter(*formattup)
             handler.setFormatter(formatter)
             logger.addHandler(handler)
             logger.setLevel(logging_level)
@@ -166,7 +170,7 @@ class Logging:
 
             # configure logger for color printing to stdout
             handler = logging.StreamHandler(stream=sys.stdout)
-            formatter = colorizeOutputFormatter(formatstr)
+            formatter = colorizeOutputFormatter(*formattup)
             handler.setFormatter(formatter)
             logger.addHandler(handler)
             logger.setLevel(logging_level)


### PR DESCRIPTION
So...

We REALLY don't need THAT much output when launching an Atomic App.

Not even Vagrant adds time to their output sometimes it takes *ages* to launch a VM.

I propose that we remove time output via the default use of Atomic App.

Although it is nice to use it with debugging however, I propose that we use epoch time instead of the default time output.

It makes it *sooooo* much cleaner this way.

```
▶ sudo atomicapp run projectatomic/helloapache --provider=docker
[INFO] - main.py - Action/Mode Selected is: run
[INFO] - base.py - Unpacking image: projectatomic/helloapache to /var/lib/atomicapp/projectatomic-helloapache-6740d881f105
[INFO] - container.py - Skipping pulling Docker image: projectatomic/helloapache
[INFO] - container.py - Extracting nulecule data from image: projectatomic/helloapache to /var/lib/atomicapp/projectatomic-helloapache-6740d881f105
11b01dfaf7ec7d1d2d4e098541ea3304738e6986a150c36e98eab4274ea2a577
[INFO] - base.py - Provider not specified, using default provider - kubernetes
[WARNING] - plugin.py - Configuration option 'providerconfig' not found
[WARNING] - plugin.py - Configuration option 'providerconfig' not found
[INFO] - docker.py - Deploying to provider: Docker
302f6d4658324a7099c9e07f335ddc5344ca992d0e87ff0da67c9dc58be8ad52
docker: Error response from daemon: failed to create endpoint default_centos-httpd_70ff70b9342d on network bridge: Bind for 0.0.0.0:80 failed: port is already allocated.

▶ sudo atomicapp -v run projectatomic/helloapache --provider=docker
1457647048 - [INFO] - cli/main.py - Action/Mode Selected is: run
1457647048 - [DEBUG] - cli/main.py - Final parsed cmdline: run -v projectatomic/helloapache --provider=docker
1457647048 - [DEBUG] - nulecule/main.py - NuleculeManager init app_path: /var/lib/atomicapp/projectatomic-helloapache-e6fc80584ff0
1457647048 - [DEBUG] - nulecule/main.py - NuleculeManager init image: projectatomic/helloapache
1457647048 - [DEBUG] - nulecule/main.py - Request to unpack to projectatomic/helloapache to /var/lib/atomicapp/projectatomic-helloapache-e6fc80584ff0
1457647048 - [INFO] - nulecule/base.py - Unpacking image: projectatomic/helloapache to /var/lib/atomicapp/projectatomic-helloapache-e6fc80584ff0
1457647048 - [INFO] - nulecule/container.py - Skipping pulling Docker image: projectatomic/helloapache
1457647048 - [INFO] - nulecule/container.py - Extracting nulecule data from image: projectatomic/helloapache to /var/lib/atomicapp/projectatomic-helloapache-e6fc80584ff0
1457647048 - [DEBUG] - nulecule/container.py - Creating docker container: /usr/bin/docker create --entrypoint /bin/true projectatomic/helloapache
1457647049 - [DEBUG] - nulecule/container.py - Copying data from Docker container: /usr/bin/docker cp 41fb827975d57e57c9e6fbb8e0afbf1c7235ce64a8ca5b6ae915bf5cd8e63836:/application-entity /tmp/nulecule-152a8ebc-e70b-11e5-acfd-3402868080db
1457647049 - [DEBUG] - nulecule/container.py - Copying nulecule data from /tmp/nulecule-152a8ebc-e70b-11e5-acfd-3402868080db to /var/lib/atomicapp/projectatomic-helloapache-e6fc80584ff0
1457647049 - [DEBUG] - nulecule/container.py - Removing tmp dir: /tmp/nulecule-152a8ebc-e70b-11e5-acfd-3402868080db
1457647049 - [DEBUG] - atomicapp/utils.py - Recursively removing directory: /tmp/nulecule-152a8ebc-e70b-11e5-acfd-3402868080db
1457647049 - [DEBUG] - nulecule/container.py - Removing Docker container: /usr/bin/docker rm -f 41fb827975d57e57c9e6fbb8e0afbf1c7235ce64a8ca5b6ae915bf5cd8e63836
41fb827975d57e57c9e6fbb8e0afbf1c7235ce64a8ca5b6ae915bf5cd8e63836
1457647049 - [DEBUG] - atomicapp/plugin.py - Loading providers from /usr/local/lib/python2.7/dist-packages/atomicapp-0.4.3-py2.7.egg/atomicapp/providers
1457647049 - [DEBUG] - atomicapp/plugin.py - Loading providers from /usr/local/lib/python2.7/dist-packages/atomicapp-0.4.3-py2.7.egg/atomicapp/providers
1457647049 - [INFO] - nulecule/base.py - Provider not specified, using default provider - kubernetes
1457647049 - [DEBUG] - atomicapp/plugin.py - Found provider <class 'docker.DockerProvider'>
1457647049 - [WARNING] - atomicapp/plugin.py - Configuration option 'providerconfig' not found
1457647049 - [DEBUG] - atomicapp/plugin.py - Found provider <class 'docker.DockerProvider'>
1457647049 - [WARNING] - atomicapp/plugin.py - Configuration option 'providerconfig' not found
1457647049 - [DEBUG] - providers/docker.py - Given config: {u'image': u'centos/httpd', u'hostport': 80, 'namespace': 'default', 'provider': 'kubernetes'}
1457647049 - [DEBUG] - providers/docker.py - Namespace: default
1457647049 - [INFO] - providers/docker.py - Deploying to provider: Docker
```