### PR TITLE
refactor exceptions, fix #621, fix #622

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -51,84 +51,53 @@ def print_app_location(app_path):
 
 
 def cli_genanswers(args):
-    try:
-        argdict = args.__dict__
-        nm = NuleculeManager(app_spec=argdict['app_spec'],
-                             destination='none')
-        nm.genanswers(**argdict)
-        Utils.rm_dir(nm.app_path)  # clean up files
-        sys.exit(0)
-    except NuleculeException as e:
-        logger.error(e)
-        sys.exit(1)
-    except Exception as e:
-        logger.error(e, exc_info=True)
-        sys.exit(1)
+    argdict = args.__dict__
+    nm = NuleculeManager(app_spec=argdict['app_spec'],
+                         destination='none')
+    nm.genanswers(**argdict)
+    Utils.rm_dir(nm.app_path)  # clean up files
+    sys.exit(0)
 
 
 def cli_fetch(args):
-    try:
-        argdict = args.__dict__
-        destination = argdict['destination']
-        nm = NuleculeManager(app_spec=argdict['app_spec'],
-                             destination=destination,
-                             cli_answers=argdict['cli_answers'],
-                             answers_file=argdict['answers'])
-        nm.fetch(**argdict)
-        # Clean up the files if the user asked us to. Otherwise
-        # notify the user where they can manage the application
-        if destination and destination.lower() == 'none':
-            Utils.rm_dir(nm.app_path)
-        else:
-            print_app_location(nm.app_path)
-        sys.exit(0)
-    except NuleculeException as e:
-        logger.error(e)
-        sys.exit(1)
-    except Exception as e:
-        logger.error(e, exc_info=True)
-        sys.exit(1)
+    argdict = args.__dict__
+    destination = argdict['destination']
+    nm = NuleculeManager(app_spec=argdict['app_spec'],
+                         destination=destination,
+                         cli_answers=argdict['cli_answers'],
+                         answers_file=argdict['answers'])
+    nm.fetch(**argdict)
+    # Clean up the files if the user asked us to. Otherwise
+    # notify the user where they can manage the application
+    if destination and destination.lower() == 'none':
+        Utils.rm_dir(nm.app_path)
+    else:
+        print_app_location(nm.app_path)
+    sys.exit(0)
 
 
 def cli_run(args):
-    try:
-        argdict = args.__dict__
-        destination = argdict['destination']
-        nm = NuleculeManager(app_spec=argdict['app_spec'],
-                             destination=destination,
-                             cli_answers=argdict['cli_answers'],
-                             answers_file=argdict['answers'])
-        nm.run(**argdict)
-        # Clean up the files if the user asked us to. Otherwise
-        # notify the user where they can manage the application
-        if destination and destination.lower() == 'none':
-            Utils.rm_dir(nm.app_path)
-        else:
-            print_app_location(nm.app_path)
-        sys.exit(0)
-    except DockerException as e:
-        logger.error(e)
-        sys.exit(1)
-    except NuleculeException as e:
-        logger.error(e)
-        sys.exit(1)
-    except Exception as e:
-        logger.error(e, exc_info=True)
-        sys.exit(1)
+    argdict = args.__dict__
+    destination = argdict['destination']
+    nm = NuleculeManager(app_spec=argdict['app_spec'],
+                         destination=destination,
+                         cli_answers=argdict['cli_answers'],
+                         answers_file=argdict['answers'])
+    nm.run(**argdict)
+    # Clean up the files if the user asked us to. Otherwise
+    # notify the user where they can manage the application
+    if destination and destination.lower() == 'none':
+        Utils.rm_dir(nm.app_path)
+    else:
+        print_app_location(nm.app_path)
+    sys.exit(0)
 
 
 def cli_stop(args):
-    try:
-        argdict = args.__dict__
-        nm = NuleculeManager(app_spec=argdict['app_spec'])
-        nm.stop(**argdict)
-        sys.exit(0)
-    except NuleculeException as e:
-        logger.error(e)
-        sys.exit(1)
-    except Exception as e:
-        logger.error(e, exc_info=True)
-        sys.exit(1)
+    argdict = args.__dict__
+    nm = NuleculeManager(app_spec=argdict['app_spec'])
+    nm.stop(**argdict)
+    sys.exit(0)
 
 
 # Create a custom action parser. Need this because for some args we don't
@@ -142,6 +111,20 @@ class TrueOrFalseAction(argparse.Action):
         else:
             booleanvalue = False
         setattr(namespace, self.dest, booleanvalue)
+
+
+def cli_func_exec(cli_func, cli_func_args):
+    try:
+        cli_func(cli_func_args)
+    except DockerException as e:
+        logger.error(e)
+        sys.exit(1)
+    except NuleculeException as e:
+        logger.error(e)
+        sys.exit(1)
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        sys.exit(1)
 
 
 class CLI():
@@ -457,7 +440,7 @@ class CLI():
         lock = LockFile(os.path.join(Utils.getRoot(), LOCK_FILE))
         try:
             lock.acquire(timeout=-1)
-            args.func(args)
+            cli_func_exec(args.func, args)
         except AttributeError:
             if hasattr(args, 'func'):
                 raise

--- a/atomicapp/nulecule/container.py
+++ b/atomicapp/nulecule/container.py
@@ -31,10 +31,18 @@ class DockerHandler(object):
             except subprocess.CalledProcessError as e:
                 if "client and server don't have same version" in e.output \
                         or "client is newer than server" in e.output:
-                    print("\nThe docker version in this Atomic App differs "
-                          "greatly from the host version.\nPlease use a different "
-                          "Atomic App version for this host.\n")
-                raise e
+                    raise DockerException("\nThe docker version in this "
+                                          "Atomic App differs greatly from "
+                                          "the host version.\nPlease use a "
+                                          "different Atomic App version for "
+                                          "this host.\n")
+                elif "Is your docker daemon up and running" in e.output or \
+                     "Are you trying to connect to a TLS-enabled daemon " \
+                     "without TLS" in e.output:
+                    raise DockerException("Could not connect to the "
+                                          "docker daemon.")
+                else:
+                    raise DockerException(e.output)
 
     def pull(self, image, update=False):
         """


### PR DESCRIPTION
About https://github.com/projectatomic/atomicapp/commit/3aa144ae4110341ec9afe887c4e074e295f5573d

I have removed the `try-except` block from `cli_genanswers`, `cli_fetch`, `cli_run`, `cli_stop` since `except` clause was/should be the same for all of those, and moved the `except` statements to another function [`cli_func_exec`](https://github.com/containscafeine/atomicapp/commit/3aa144ae4110341ec9afe887c4e074e295f5573d#diff-91e24f7bd4ae0b7cae29db3faca25ff6R116).

So now, during cli.run(), instead of `args.func(args)`, [`cli_func_exec(args.func, args)`](https://github.com/containscafeine/atomicapp/commit/3aa144ae4110341ec9afe887c4e074e295f5573d#diff-91e24f7bd4ae0b7cae29db3faca25ff6R443) is called which further executes the specified `cli_*` function, but catches all the exceptions itself instead of each `cli_*` function having to worry about those.

@dustymabe @cdrage does this make sense?