### PR TITLE
Docker-run file with multi-line command supported

### DIFF
--- a/atomicapp/providers/docker.py
+++ b/atomicapp/providers/docker.py
@@ -90,6 +90,8 @@ class DockerProvider(Provider):
             label_run = None
             with open(artifact_path, "r") as fp:
                 label_run = fp.read().strip()
+                # if docker-run provided as multiline command
+                label_run = ' '.join(label_run.split('\\\n'))
             run_args = label_run.split()
 
             # If --name is provided, do not re-name due to potential linking of containers. Warn user instead.

--- a/tests/units/providers/docker_artifact_test/run-with-backslashes
+++ b/tests/units/providers/docker_artifact_test/run-with-backslashes
@@ -1,0 +1,6 @@
+docker run \
+-d \
+-p \
+80:80 \
+--name centos7 \
+centos7

--- a/tests/units/providers/test_docker_provider.py
+++ b/tests/units/providers/test_docker_provider.py
@@ -78,3 +78,15 @@ class TestDockerProviderBase(unittest.TestCase):
         provider.artifacts = [self.artifact_dir + 'hello-world-one']
         with pytest.raises(ProviderFailedException):
             provider.run()
+
+    def test_docker_run_with_backslashes(self):
+        data = {'namespace': 'test', 'provider': 'docker'}
+        provider = self.prepare_provider(data)
+        provider.init()
+        provider.artifacts = [
+                self.artifact_dir + 'run-with-backslashes',
+                ]
+        expected_output = 'docker run -d -p 80:80 --name centos7 centos7'
+        with mock.patch('atomicapp.providers.docker.logger') as mock_logger:
+            provider.run()
+            mock_logger.info.assert_called_with('DRY-RUN: %s', expected_output)


### PR DESCRIPTION
If user has provided a docker-run artifact with multi-line command then it can be parsed now, by removing the backslashes(`\`) and `\n`.

Fixes issue #617