### PR TITLE
Util to gather what user is running Atomic App and which home dir it should use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV ATOMICAPPVERSION="0.4.5"
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.git/Dockerfile.centos
+++ b/Dockerfiles.git/Dockerfile.centos
@@ -7,8 +7,8 @@ ENV ATOMICAPPVERSION="0.4.5"
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.git/Dockerfile.debian
+++ b/Dockerfiles.git/Dockerfile.debian
@@ -5,8 +5,8 @@ MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 ENV ATOMICAPPVERSION="0.4.5"
 
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.git/Dockerfile.fedora
+++ b/Dockerfiles.git/Dockerfile.fedora
@@ -7,8 +7,8 @@ ENV ATOMICAPPVERSION="0.4.5"
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.pkgs/Dockerfile.centos
+++ b/Dockerfiles.pkgs/Dockerfile.centos
@@ -4,14 +4,14 @@ MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 # Check https://bodhi.fedoraproject.org/updates/?packages=atomicapp
 # for the most recent builds of atomicapp in epel
-ENV ATOMICAPPVERSION="0.1.12"
+ENV ATOMICAPPVERSION="0.4.5"
 ENV TESTING="--enablerepo=epel-testing"
 
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /atomicapp
 

--- a/Dockerfiles.pkgs/Dockerfile.fedora
+++ b/Dockerfiles.pkgs/Dockerfile.fedora
@@ -4,14 +4,14 @@ MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 # Check https://bodhi.fedoraproject.org/updates/?packages=atomicapp
 # for the most recent builds of atomicapp in fedora
-ENV ATOMICAPPVERSION="0.1.12"
+ENV ATOMICAPPVERSION="0.4.5"
 ENV TESTING="--enablerepo=updates-testing"
 
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /atomicapp
 

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -342,7 +342,7 @@ class Utils(object):
         Returns:
             (bool): True == we are in a container
         """
-        if os.path.isdir(HOST_DIR):
+        if os.path.isfile('/.dockerenv') and os.path.isfile('/.dockerinit') and os.path.isdir(HOST_DIR):
             return True
         else:
             return False

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -335,7 +335,9 @@ class Utils(object):
     @staticmethod
     def inContainer():
         """
-        Determine if we are running inside a container or not.
+        Determine if we are running inside a container or not. This is done by
+        checking to see if /host has been passed as well as if .dockerenv and
+        .dockerinit files exist
 
         Returns:
             (bool): True == we are in a container
@@ -376,6 +378,58 @@ class Utils(object):
     def rm_dir(directory):
         logger.debug('Recursively removing directory: %s' % directory)
         distutils.dir_util.remove_tree(directory)
+
+    @staticmethod
+    def getUserName():
+        """
+        Finds the username of the user running the application. Uses the
+        SUDO_USER and USER environment variables. If runnning within a
+        container, SUDO_USER and USER varibles must be passed for proper
+        detection.
+        Ex. docker run -v /:/host -e SUDO_USER -e USER foobar
+        """
+        sudo_user = os.environ.get('SUDO_USER')
+
+        if os.getegid() == 0 and sudo_user is None:
+            user = 'root'
+        elif sudo_user is not None:
+            user = sudo_user
+        else:
+            user = os.environ.get('USER')
+        return user
+
+    @staticmethod
+    def getUserHome():
+        """
+        Finds the home directory of the user running the application.
+        If runnning within a container, the root dir must be passed as
+        a volume.
+        Ex. docker run -v /:/host -e SUDO_USER -e USER foobar
+        """
+        logger.debug("Finding the users home directory")
+        user = Utils.getUserName()
+        incontainer = Utils.inContainer()
+
+        # Check to see if we are running in a container. If we are we
+        # will chroot into the /host path before calling os.path.expanduser
+        if incontainer:
+            os.chroot(HOST_DIR)
+
+        # Call os.path.expanduser to determine the user's home dir.
+        # See https://docs.python.org/2/library/os.path.html#os.path.expanduser
+        # Warn if none is detected, don't error as not having a home
+        # dir doesn't mean we fail.
+        home = os.path.expanduser("~%s" % user)
+        if home == ("~%s" % user):
+            logger.error("No home directory exists for user %s" % user)
+
+        # Back out of chroot if necessary
+        if incontainer:
+            os.chroot("../..")
+
+        logger.debug("Running as user %s. Using home directory %s for configuration data"
+                     % (user, home))
+        return home
 
     @staticmethod
     def make_rest_request(method, url, verify=True, data=None):


### PR DESCRIPTION
This call finds out what user is running the Atomic App.

Whether they are:
  sudo
  root
  user

If it is running under sudo, this util will find the user running the
sudo command.

Once the user is found, os.path.expanduser(user) is utilized to find the
home directory. If a home directory is not found atomic app will error
out.

Fixes https://github.com/projectatomic/atomicapp/issues/656

This util will be used to implement default config locations for OpenShift and k8s providers.