### PR TITLE
Fix persistent storage

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -38,7 +38,6 @@ from atomicapp.constants import (APP_ENT_PATH,
                                  NAME_KEY,
                                  INHERIT_KEY,
                                  ARTIFACTS_KEY,
-                                 REQUIREMENTS_KEY,
                                  DEFAULT_PROVIDER)
 from atomicapp.utils import Utils
 from atomicapp.requirements import Requirements
@@ -195,14 +194,11 @@ class Nulecule(NuleculeBase):
         """
         provider_key, provider = self.get_provider(provider_key, dryrun)
 
-        # Process preliminary requirements
-        # Pass configuration, path of the app, graph, provider as well as dry-run
-        # for provider init()
-        if REQUIREMENTS_KEY in self.graph[0]:
-            logger.debug("Requirements key detected. Running action.")
-            r = Requirements(self.config, self.basepath, self.graph[0][REQUIREMENTS_KEY],
-                             provider_key, dryrun)
-            r.run()
+        # Process preliminary requirements before componenets
+        if self.requirements:
+            logger.debug("Requirements detected. Running action.")
+            Requirements(self.config, self.basepath, self.requirements,
+                         provider_key, dryrun).run()
 
         # Process components
         for component in self.components:


### PR DESCRIPTION
  __Fix detection of no persistentVolumes__

  Kubernetes recently changed that if you use `kubectl get pv` with no pv
  present, the columns should not appear.

  Before 1.0.0:
```
  ▶ kubectl get pvc 
NAME      STATUS    VOLUME    CAPACITY   ACCESSMODES  AGE
```

  After:
```
  ▶ kubectl get pvc
```

  Hence the need to add <= 2 instead of == 2

 __Requirements should retrieve from Nulecule object not graph__

  Requirements previously retrieved from graph:
```
 graph:
     ...
     requirements:
       - persistentVolume:
           name: "var-log-httpd"
           accessMode: "ReadWrite"
           size: 4
```

  This is an undesired affect and should retrieve from it's own object:
```
graph:
     ... 
requirements:
   - persistentVolume:
       name: "var-log-httpd"
       accessMode: "ReadWrite"
       size: 4
```

Fixes #660 