### PR TITLE
add pass for improved readability

### DIFF
--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -117,8 +117,8 @@ class Provider(object):
 
 
 class ProviderFailedException(Exception):
-
     """Error during provider execution"""
+    pass
 
 
 class Plugin(object):


### PR DESCRIPTION
Added pass statement to `ProviderFailedException` class for improved readability.
Does this make sense?