### PR TITLE
Revert back to pip packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ ADD requirements.txt ./
 
 # Install needed requirements
 RUN yum install -y epel-release && \
-    yum install -y --setopt=tsflags=nodocs docker && \
-    yum install -y --setopt=tsflags=nodocs $(sed s/^/python-/ requirements.txt) && \
+    yum install -y --setopt=tsflags=nodocs docker python-pip && \
+    pip install -r requirements.txt && \
+    yum remove -y python-pip && \
     yum clean all
 
 WORKDIR /atomicapp

--- a/Dockerfiles.git/Dockerfile.centos
+++ b/Dockerfiles.git/Dockerfile.centos
@@ -17,11 +17,10 @@ ADD requirements.txt ./
 
 # Install needed requirements
 RUN yum install -y epel-release && \
-    yum install -y --setopt=tsflags=nodocs docker && \
-    yum install -y --setopt=tsflags=nodocs $(sed s/^/python-/ requirements.txt) && \
+    yum install -y --setopt=tsflags=nodocs docker python-pip && \
+    pip install -r requirements.txt && \
+    yum remove -y python-pip && \
     yum clean all
-
-WORKDIR /atomicapp
 
 # If a volume doesn't get mounted over /atomicapp (like when running in 
 # an openshift pod) then open up permissions so files can be copied into

--- a/Dockerfiles.git/Dockerfile.fedora
+++ b/Dockerfiles.git/Dockerfile.fedora
@@ -16,8 +16,9 @@ WORKDIR /opt/atomicapp
 ADD requirements.txt ./
 
 # Install needed requirements
-RUN dnf install -y --setopt=tsflags=nodocs docker && \
-    dnf install -y --setopt=tsflags=nodocs $(sed s/^/python-/ requirements.txt) && \
+RUN dnf install -y --setopt=tsflags=nodocs docker python-pip && \
+    pip install -r requirements.txt && \
+    dnf remove -y python-pip && \
     dnf clean all
 
 WORKDIR /atomicapp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-anymarkup
-lockfile
-jsonpointer
-requests
-websocket-client
+anymarkup==0.5.0
+lockfile==0.12.2
+jsonpointer==1.10
+requests==2.9.1
+websocket-client==0.35.0


### PR DESCRIPTION
Go back to using pip packages with hard-coded versions rather than relying
on waiting upstream for OS Python related packages.

This opens up opportunity for adding third-party packages not yet included on their respective operating system.

(Note: adding `pykube` and a future OpenShift library to the mix)

Also we will use hard-coded versions in order to prevent breakage in the future.