### PR TITLE
Added defaultdict to reduce checks on dict and errors

### DIFF
--- a/atomicapp/applibs/appcollections.py
+++ b/atomicapp/applibs/appcollections.py
@@ -1,0 +1,12 @@
+from collections import defaultdict
+from collections import OrderedDict
+
+
+class OrderedDefaultDict(OrderedDict, defaultdict):
+    """
+    Combines the power of two dictionaries i.e. OrderedDict and defaultdict
+    from collections module, to make a OrderedDefaultDict.
+    """
+    def __init__(self, default_factory=None, *args, **kwargs):
+        super(OrderedDefaultDict, self).__init__(*args, **kwargs)
+        self.default_factory = default_factory

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -25,7 +25,6 @@ import tarfile
 import time
 from urlparse import urljoin
 from urllib import urlencode
-from collections import OrderedDict
 import websocket
 
 from atomicapp.utils import Utils
@@ -40,6 +39,7 @@ from atomicapp.constants import (PROVIDER_AUTH_KEY,
                                  PROVIDER_CA_KEY,
                                  OPENSHIFT_POD_CA_FILE)
 from atomicapp.providers.lib.kubeconfig import KubeConfig
+from atomicapp.applibs.appcollections import OrderedDefaultDict
 from requests.exceptions import SSLError
 import logging
 logger = logging.getLogger(LOGGER_DEFAULT)
@@ -332,7 +332,7 @@ class OpenShiftProvider(Provider):
 
     def init(self):
         # Parsed artifacts. Key is kind of artifacts. Value is list of artifacts.
-        self.openshift_artifacts = OrderedDict()
+        self.openshift_artifacts = OrderedDefaultDict(list)
 
         self._set_config_values()
 
@@ -504,14 +504,10 @@ class OpenShiftProvider(Provider):
             # add all processed object to artifacts dict
             for obj in processed_objects:
                 obj_kind = obj["kind"].lower()
-                if obj_kind not in self.openshift_artifacts.keys():
-                    self.openshift_artifacts[obj_kind] = []
                 self.openshift_artifacts[obj_kind].append(obj)
             return
 
         # add parsed artifact to dict
-        if kind not in self.openshift_artifacts.keys():
-            self.openshift_artifacts[kind] = []
         self.openshift_artifacts[kind].append(data)
 
     def _process_template(self, template):


### PR DESCRIPTION
When we know that the dict will have values as list, it is beneficial to use the defaultdict datatype,
we don't have to put an extra code of checks and validations thereby reducing the code and errors.