### PR TITLE
Artifacts should be specified for the provider

### DIFF
--- a/atomicapp/nulecule/lib.py
+++ b/atomicapp/nulecule/lib.py
@@ -120,6 +120,17 @@ class NuleculeBase(object):
         # If provider_key isn't provided via CLI, let's grab it the configuration
         if provider_key is None:
             provider_key = self.config.get(GLOBAL_CONF)[PROVIDER_KEY]
+
+        # get a list of all the providers whose artifacts are specified in
+        # Nulecule file into 'providers'
+        providers = []
+        for graph in self.graph:
+            providers.extend(graph['artifacts'].keys())
+        if provider_key not in providers:
+            raise NuleculeException("Artifacts for provider - '{}', not "
+                                    "specified in 'Nulecule' file."
+                                    .format(provider_key))
+
         provider_class = self.plugin.getProvider(provider_key)
         if provider_class is None:
             raise NuleculeException("Invalid Provider - '{}', provided in "


### PR DESCRIPTION
For a provider mentioned by the user, artifacts should be present in Nulecule file. Earlier if a provider was mentioned and even if that provider's artifacts were not specified in Nulecule file, Atomic App would go ahead. Now it fails error out if artifacts for that provider are not mentioned in Nulecule file.

Fixes issue #641
