### PR TITLE
Dashes added to CLI commands to distinguish provider config data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV ATOMICAPPVERSION="0.4.5"
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.git/Dockerfile.centos
+++ b/Dockerfiles.git/Dockerfile.centos
@@ -7,8 +7,8 @@ ENV ATOMICAPPVERSION="0.4.5"
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.git/Dockerfile.debian
+++ b/Dockerfiles.git/Dockerfile.debian
@@ -5,8 +5,8 @@ MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 ENV ATOMICAPPVERSION="0.4.5"
 
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.git/Dockerfile.fedora
+++ b/Dockerfiles.git/Dockerfile.fedora
@@ -7,8 +7,8 @@ ENV ATOMICAPPVERSION="0.4.5"
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /opt/atomicapp
 

--- a/Dockerfiles.pkgs/Dockerfile.centos
+++ b/Dockerfiles.pkgs/Dockerfile.centos
@@ -4,14 +4,14 @@ MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 # Check https://bodhi.fedoraproject.org/updates/?packages=atomicapp
 # for the most recent builds of atomicapp in epel
-ENV ATOMICAPPVERSION="0.1.12"
+ENV ATOMICAPPVERSION="0.4.5"
 ENV TESTING="--enablerepo=epel-testing"
 
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /atomicapp
 

--- a/Dockerfiles.pkgs/Dockerfile.fedora
+++ b/Dockerfiles.pkgs/Dockerfile.fedora
@@ -4,14 +4,14 @@ MAINTAINER Red Hat, Inc. <container-tools@redhat.com>
 
 # Check https://bodhi.fedoraproject.org/updates/?packages=atomicapp
 # for the most recent builds of atomicapp in fedora
-ENV ATOMICAPPVERSION="0.1.12"
+ENV ATOMICAPPVERSION="0.4.5"
 ENV TESTING="--enablerepo=updates-testing"
 
 LABEL io.projectatomic.nulecule.atomicappversion=${ATOMICAPPVERSION} \
       io.openshift.generate.job=true \
       io.openshift.generate.token.as=env:TOKEN_ENV_VAR \
-      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
-      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
+      RUN="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} run \${OPT3}" \
+      STOP="docker run -it --rm \${OPT1} --privileged -v \${PWD}:/atomicapp -v /run:/run -v /:/host --net=host --name \${NAME} -e USER -e SUDO_USER -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} \${OPT2} stop \${OPT3}"
 
 WORKDIR /atomicapp
 

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -247,6 +247,10 @@ class CLI():
             dest="provider-api",
             help='Value for provider-api answers option.')
         globals_parser.add_argument(
+            "--provider-auth",
+            dest="provider-auth",
+            help='Value for provider-auth answers option.')
+        globals_parser.add_argument(
             "--logtype",
             dest="logtype",
             choices=['cockpit', 'color', 'nocolor', 'none'],
@@ -436,7 +440,7 @@ class CLI():
         # Take the arguments that correspond to "answers" config file data
         # and make a dictionary of it to pass along in args.
         setattr(args, 'cli_answers', {})
-        for item in ['provider-api', 'provider-cafile',
+        for item in ['provider-api', 'provider-cafile', 'provider-auth',
                      'provider-config', 'provider-tlsverify', 'namespace']:
             if hasattr(args, item) and getattr(args, item) is not None:
                 args.cli_answers[item] = getattr(args, item)

--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -227,25 +227,25 @@ class CLI():
             dest="namespace",
             help=('The namespace to use in the target provider'))
         globals_parser.add_argument(
-            "--providertlsverify",
-            dest="providertlsverify",
+            "--provider-tlsverify",
+            dest="provider-tlsverify",
             action=TrueOrFalseAction,
             choices=['True', 'False'],
             help=('''
-                Value for providertlsverify answers option.
+                Value for provider-tlsverify answers option.
                 --providertlsverify=False to disable tls verification'''))
         globals_parser.add_argument(
-            "--providerconfig",
-            dest="providerconfig",
-            help='Value for providerconfig answers option.')
+            "--provider-config",
+            dest="provider-config",
+            help='Value for provider-config answers option.')
         globals_parser.add_argument(
-            "--providercafile",
-            dest="providercafile",
-            help='Value for providercafile answers option.')
+            "--provider-cafile",
+            dest="provider-cafile",
+            help='Value for provider-cafile answers option.')
         globals_parser.add_argument(
-            "--providerapi",
-            dest="providerapi",
-            help='Value for providerapi answers option.')
+            "--provider-api",
+            dest="provider-api",
+            help='Value for provider-api answers option.')
         globals_parser.add_argument(
             "--logtype",
             dest="logtype",
@@ -436,8 +436,8 @@ class CLI():
         # Take the arguments that correspond to "answers" config file data
         # and make a dictionary of it to pass along in args.
         setattr(args, 'cli_answers', {})
-        for item in ['providerapi', 'providercafile',
-                     'providerconfig', 'providertlsverify', 'namespace']:
+        for item in ['provider-api', 'provider-cafile',
+                     'provider-config', 'provider-tlsverify', 'namespace']:
             if hasattr(args, item) and getattr(args, item) is not None:
                 args.cli_answers[item] = getattr(args, item)
 

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -70,11 +70,11 @@ DEFAULT_ANSWERS = {
 }
 
 PROVIDERS = ["docker", "kubernetes", "openshift", "marathon"]
-PROVIDER_API_KEY = "providerapi"
+PROVIDER_API_KEY = "provider-api"
 ACCESS_TOKEN_KEY = "accesstoken"
-PROVIDER_CONFIG_KEY = "providerconfig"
-PROVIDER_TLS_VERIFY_KEY = "providertlsverify"
-PROVIDER_CA_KEY = "providercafile"
+PROVIDER_CONFIG_KEY = "provider-config"
+PROVIDER_TLS_VERIFY_KEY = "provider-tlsverify"
+PROVIDER_CA_KEY = "provider-cafile"
 
 # Persistent Storage Formats
 PERSISTENT_STORAGE_FORMAT = ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -71,7 +71,7 @@ DEFAULT_ANSWERS = {
 
 PROVIDERS = ["docker", "kubernetes", "openshift", "marathon"]
 PROVIDER_API_KEY = "provider-api"
-ACCESS_TOKEN_KEY = "provider-auth"
+PROVIDER_AUTH_KEY = "provider-auth"
 PROVIDER_CONFIG_KEY = "provider-config"
 PROVIDER_TLS_VERIFY_KEY = "provider-tlsverify"
 PROVIDER_CA_KEY = "provider-cafile"

--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -71,7 +71,7 @@ DEFAULT_ANSWERS = {
 
 PROVIDERS = ["docker", "kubernetes", "openshift", "marathon"]
 PROVIDER_API_KEY = "provider-api"
-ACCESS_TOKEN_KEY = "accesstoken"
+ACCESS_TOKEN_KEY = "provider-auth"
 PROVIDER_CONFIG_KEY = "provider-config"
 PROVIDER_TLS_VERIFY_KEY = "provider-tlsverify"
 PROVIDER_CA_KEY = "provider-cafile"

--- a/atomicapp/providers/lib/kubeconfig.py
+++ b/atomicapp/providers/lib/kubeconfig.py
@@ -1,7 +1,7 @@
 import anymarkup
 
 from atomicapp.plugin import ProviderFailedException
-from atomicapp.constants import (ACCESS_TOKEN_KEY,
+from atomicapp.constants import (PROVIDER_AUTH_KEY,
                                  LOGGER_DEFAULT,
                                  NAMESPACE_KEY,
                                  PROVIDER_API_KEY,
@@ -112,7 +112,7 @@ class KubeConfig(object):
             ca = cluster["cluster"]["certificate-authority"]
 
         return {PROVIDER_API_KEY: url,
-                ACCESS_TOKEN_KEY: token,
+                PROVIDER_AUTH_KEY: token,
                 NAMESPACE_KEY: namespace,
                 PROVIDER_TLS_VERIFY_KEY: tls_verify,
                 PROVIDER_CA_KEY: ca}

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -29,7 +29,7 @@ import websocket
 
 from atomicapp.utils import Utils
 from atomicapp.plugin import Provider, ProviderFailedException
-from atomicapp.constants import (ACCESS_TOKEN_KEY,
+from atomicapp.constants import (PROVIDER_AUTH_KEY,
                                  ANSWERS_FILE,
                                  DEFAULT_NAMESPACE,
                                  LOGGER_DEFAULT,
@@ -630,7 +630,7 @@ class OpenShiftProvider(Provider):
 
         # initialize result to default values
         result = {PROVIDER_API_KEY: self.providerapi,
-                  ACCESS_TOKEN_KEY: self.access_token,
+                  PROVIDER_AUTH_KEY: self.access_token,
                   NAMESPACE_KEY: self.namespace,
                   PROVIDER_TLS_VERIFY_KEY: self.provider_tls_verify,
                   PROVIDER_CA_KEY: self.provider_ca}
@@ -670,7 +670,7 @@ class OpenShiftProvider(Provider):
         logger.debug("config values: %s" % result)
 
         # this items are required, they have to be not None
-        for k in [PROVIDER_API_KEY, ACCESS_TOKEN_KEY, NAMESPACE_KEY]:
+        for k in [PROVIDER_API_KEY, PROVIDER_AUTH_KEY, NAMESPACE_KEY]:
             if result[k] is None:
                 msg = "You need to set %s in %s" % (k, ANSWERS_FILE)
                 logger.error(msg)
@@ -678,7 +678,7 @@ class OpenShiftProvider(Provider):
 
         # set config values
         self.providerapi = result[PROVIDER_API_KEY]
-        self.access_token = result[ACCESS_TOKEN_KEY]
+        self.access_token = result[PROVIDER_AUTH_KEY]
         self.namespace = result[NAMESPACE_KEY]
         self.provider_tls_verify = result[PROVIDER_TLS_VERIFY_KEY]
         if result[PROVIDER_CA_KEY]:

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -342,7 +342,7 @@ class Utils(object):
         Returns:
             (bool): True == we are in a container
         """
-        if os.path.isdir(HOST_DIR):
+        if os.path.isfile('/.dockerenv') and os.path.isfile('/.dockerinit') and os.path.isdir(HOST_DIR):
             return True
         else:
             return False

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -335,7 +335,9 @@ class Utils(object):
     @staticmethod
     def inContainer():
         """
-        Determine if we are running inside a container or not.
+        Determine if we are running inside a container or not. This is done by
+        checking to see if /host has been passed as well as if .dockerenv and
+        .dockerinit files exist
 
         Returns:
             (bool): True == we are in a container
@@ -376,6 +378,58 @@ class Utils(object):
     def rm_dir(directory):
         logger.debug('Recursively removing directory: %s' % directory)
         distutils.dir_util.remove_tree(directory)
+
+    @staticmethod
+    def getUserName():
+        """
+        Finds the username of the user running the application. Uses the
+        SUDO_USER and USER environment variables. If runnning within a
+        container, SUDO_USER and USER varibles must be passed for proper
+        detection.
+        Ex. docker run -v /:/host -e SUDO_USER -e USER foobar
+        """
+        sudo_user = os.environ.get('SUDO_USER')
+
+        if os.getegid() == 0 and sudo_user is None:
+            user = 'root'
+        elif sudo_user is not None:
+            user = sudo_user
+        else:
+            user = os.environ.get('USER')
+        return user
+
+    @staticmethod
+    def getUserHome():
+        """
+        Finds the home directory of the user running the application.
+        If runnning within a container, the root dir must be passed as
+        a volume.
+        Ex. docker run -v /:/host -e SUDO_USER -e USER foobar
+        """
+        logger.debug("Finding the users home directory")
+        user = Utils.getUserName()
+        incontainer = Utils.inContainer()
+
+        # Check to see if we are running in a container. If we are we
+        # will chroot into the /host path before calling os.path.expanduser
+        if incontainer:
+            os.chroot(HOST_DIR)
+
+        # Call os.path.expanduser to determine the user's home dir.
+        # See https://docs.python.org/2/library/os.path.html#os.path.expanduser
+        # Warn if none is detected, don't error as not having a home
+        # dir doesn't mean we fail.
+        home = os.path.expanduser("~%s" % user)
+        if home == ("~%s" % user):
+            logger.error("No home directory exists for user %s" % user)
+
+        # Back out of chroot if necessary
+        if incontainer:
+            os.chroot("../..")
+
+        logger.debug("Running as user %s. Using home directory %s for configuration data"
+                     % (user, home))
+        return home
 
     @staticmethod
     def make_rest_request(method, url, verify=True, data=None):

--- a/tests/units/nulecule/test_kubeconfig.py
+++ b/tests/units/nulecule/test_kubeconfig.py
@@ -46,7 +46,7 @@ class TestKubeConfParsing(unittest.TestCase):
 
         self.assertEqual(KubeConfig.parse_kubeconf_data(kubecfg_data),
                          {'provider-api': 'server1',
-                          'accesstoken': 'token1',
+                          'provider-auth': 'token1',
                           'namespace': 'namespace1',
                           'provider-tlsverify': False,
                           'provider-cafile': None})
@@ -92,7 +92,7 @@ class TestKubeConfParsing(unittest.TestCase):
 
         self.assertEqual(KubeConfig.parse_kubeconf_data(kubecfg_data),
                          {'provider-api': 'server1',
-                          'accesstoken': 'token1',
+                          'provider-auth': 'token1',
                           'namespace': 'namespace1',
                           'provider-tlsverify': True,
                           'provider-cafile': '/foo/bar'})

--- a/tests/units/nulecule/test_kubeconfig.py
+++ b/tests/units/nulecule/test_kubeconfig.py
@@ -45,11 +45,11 @@ class TestKubeConfParsing(unittest.TestCase):
         }
 
         self.assertEqual(KubeConfig.parse_kubeconf_data(kubecfg_data),
-                         {'providerapi': 'server1',
+                         {'provider-api': 'server1',
                           'accesstoken': 'token1',
                           'namespace': 'namespace1',
-                          'providertlsverify': False,
-                          'providercafile': None})
+                          'provider-tlsverify': False,
+                          'provider-cafile': None})
 
     def test_parse_kubeconf_data_cafile(self):
         """
@@ -91,11 +91,11 @@ class TestKubeConfParsing(unittest.TestCase):
         }
 
         self.assertEqual(KubeConfig.parse_kubeconf_data(kubecfg_data),
-                         {'providerapi': 'server1',
+                         {'provider-api': 'server1',
                           'accesstoken': 'token1',
                           'namespace': 'namespace1',
-                          'providertlsverify': True,
-                          'providercafile': '/foo/bar'})
+                          'provider-tlsverify': True,
+                          'provider-cafile': '/foo/bar'})
 
     def test_parse_kubeconf_data_no_context(self):
         """

--- a/tests/units/providers/test_kubernetes_provider.py
+++ b/tests/units/providers/test_kubernetes_provider.py
@@ -60,7 +60,7 @@ class TestKubernetesProviderBase(unittest.TestCase):
         with open(provider_config_path, "w") as fp:
             fp.write(mock_content)
 
-        data = {'namespace': 'testing', 'provider': 'kubernetes', 'providerconfig': provider_config_path}
+        data = {'namespace': 'testing', 'provider': 'kubernetes', 'provider-config': provider_config_path}
         
         provider = self.prepare_provider(data)
 


### PR DESCRIPTION
This commit adds dashes to the command line (as well as answers file)
for the provider configuration data.

For example: --providercafile because --provider-cafile