### PR TITLE
Atomic App will not create redundant folder on `atomicapp stop`

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -96,7 +96,8 @@ def cli_run(args):
 
 def cli_stop(args):
     argdict = args.__dict__
-    nm = NuleculeManager(app_spec=argdict['app_spec'])
+    nm = NuleculeManager(app_spec=argdict['app_spec'],
+                         action=argdict['action'])
     nm.stop(**argdict)
     sys.exit(0)
 

--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -51,7 +51,7 @@ class NuleculeManager(object):
     """
 
     def __init__(self, app_spec, destination=None,
-                 cli_answers=None, answers_file=None):
+                 cli_answers=None, answers_file=None, action=None):
         """
         init function for NuleculeManager. Sets a few instance variables.
 
@@ -104,7 +104,10 @@ class NuleculeManager(object):
             if destination:
                 self.app_path = destination
             else:
-                self.app_path = Utils.getNewAppCacheDir(self.image)
+                if action == 'stop':
+                    raise NuleculeException("Provide the path where application is deployed.")
+                else:
+                    self.app_path = Utils.getNewAppCacheDir(self.image)
 
         logger.debug("NuleculeManager init app_path: %s", self.app_path)
         logger.debug("NuleculeManager init image: %s", self.image)


### PR DESCRIPTION
Previously when `atomicapp stop projectatomic/helloapache` was called atomicapp would create a redundant folder in `/var/lib/atomicapp` and fail saying that `answers` file not found. Though it was failing but the folder would still remain there, now there are checks added to see if user has provided
the image name and the action is stop, the at the location where it creates a directory, the new checks will cause it to fail.

Fixes issue #683
