### PR TITLE
Modify documentation to reflect changes in params

### DIFF
--- a/docs/providers/docker/overview.md
+++ b/docs/providers/docker/overview.md
@@ -30,9 +30,9 @@ answers.conf file. An example is below:
 namespace: mynamespace
 ```
 
-#### providerconfig
+#### provider-config
 This communicates directly with the docker daemon on the host. It does
-not use the `providerconfig` option.
+not use the `provider-config` option.
 
 #### Configuration Value Defaults
 

--- a/docs/providers/kubernetes/overview.md
+++ b/docs/providers/kubernetes/overview.md
@@ -43,7 +43,7 @@ One example of specifying a `provider-config` is below:
 ```
 [general]
 provider: kubernetes
-provider-config: /host/home/foo/.kube/config
+provider-config: /home/foo/.kube/config
 ```
 
 #### Configuration Value Defaults

--- a/docs/providers/kubernetes/overview.md
+++ b/docs/providers/kubernetes/overview.md
@@ -28,22 +28,22 @@ section of the answers.conf file. An example is below:
 namespace: mynamespace
 ```
 
-#### providerconfig
+#### provider-config
 
-For Kubernetes the configuration file as specified by `providerconfig`
+For Kubernetes the configuration file as specified by `provider-config`
 is optional. Hosts that have kubernetes set up and running on them
-may not need a `providerconfig` to be specified because kubernetes
+may not need a `provider-config` to be specified because kubernetes
 services are listening on default ports/addresses. However, if
 kubernetes was set up to listen on different ports, or you wish to
 connect to a remote kubernetes environment, then you will need to
 specify a location for a provider config file.
 
-One example of specifying a `providerconfig` is below:
+One example of specifying a `provider-config` is below:
 
 ```
 [general]
 provider: kubernetes
-providerconfig: /host/home/foo/.kube/config
+provider-config: /host/home/foo/.kube/config
 ```
 
 #### Configuration Value Defaults
@@ -53,7 +53,7 @@ Table 1. Kubernetes default configuration values
 Keyword  | Required | Description                                             | Default value
 ---------|----------|---------------------------------------------------------|--------------
 namespace|   no     | namespace to use with each kubectl call                 | default
-providerconfig| no  | config file that specifies how to connect to kubernetes | none
+provider-config| no  | config file that specifies how to connect to kubernetes | none
 
 
 ### Operations

--- a/docs/providers/marathon/overview.md
+++ b/docs/providers/marathon/overview.md
@@ -6,15 +6,15 @@ The Marathon provider will deploy an application into Mesos cluster
 using Marathon scheduler.
 
 ### Configuration 
-This provider requires configuration (`providerapi`) to be able to connect to Marathon API.
-If no `providerapi` is specified it will use `http://localhost:8080` as Marathon API url.
+This provider requires configuration (`provider-api`) to be able to connect to Marathon API.
+If no `provider-api` is specified it will use `http://localhost:8080` as Marathon API url.
 This configuration can be provided in the `answers.conf` file. 
 
 Example:
 
     [general]
     provider=marathon
-    providerapi=http://10.0.2.15:8080
+    provider-api=http://10.0.2.15:8080
 
 #### Configuration values
 
@@ -22,7 +22,7 @@ Table 1. Marathon default configuration values
 
 Keyword     | Required | Description                                 | Default value
 ------------|----------|---------------------------------------------|--------------------------
-providerapi |   no     |  url for Marathon REST API                  | `http://localhost:8080`
+provider-api |   no     |  url for Marathon REST API                  | `http://localhost:8080`
 
 ### Operations
 

--- a/docs/providers/openshift/overview_atomic_app.md
+++ b/docs/providers/openshift/overview_atomic_app.md
@@ -11,8 +11,8 @@ the application.
 One piece of the puzzle is telling Atomic App how to communicate with
 the OpenShift master. This can be done in one of two ways.
 
-1. Passing in the `providerconfig` value in answers.conf
-2. Passing in both the `providerapi` and `accesstoken` values in answers.conf.
+1. Passing in the `provider-config` value in answers.conf
+2. Passing in both the `provider-api` and `provider-auth` values in answers.conf.
 
 These config items are detailed below.
 
@@ -34,27 +34,27 @@ namespace: mynamespace
 **NOTE**: If there is a namespace value set in the artifact metadata
 then that value will always be used and won't be overridden.
 
-#### providerconfig
+#### provider-config
 
 For OpenShift, one way to let Atomic App know how to communicate with
 the master is by re-using the provider config file that already exists
 on a user's machine.  Basically whatever the user can do with the `oc`
 command, Atomic App can do by re-using the same provider config.
 
-One example of specifying a `providerconfig` is below:
+One example of specifying a `provider-config` is below:
 
 ```
 [general]
 provider = openshift
-providerconfig = /home/user/.kube/config
+provider-config = /home/user/.kube/config
 ```
 
-#### providerapi + accesstoken
+#### provider-api + provider-auth
 
 Another to pass credential information in is by passing in both the
 location where the openshift API is being served, as well as the
 access token that can be used to authenticate. These are done with the 
-`providerapi` and `accesstoken` config variables in the `[general]`
+`provider-api` and `provider-auth` config variables in the `[general]`
 section within answers.conf.
 
 An example of this is below:
@@ -62,8 +62,8 @@ An example of this is below:
 ```
 [general]
 provider = openshift
-providerapi = https://10.1.2.2:8443
-accesstoken = sadfasdfasfasfdasfasfasdfsafasfd
+provider-api = https://10.1.2.2:8443
+provider-auth = sadfasdfasfasfdasfasfasdfsafasfd
 namespace = mynamespace
 ```
 
@@ -71,29 +71,29 @@ namespace = mynamespace
 `oc whoami -t` or if you are not using `oc` client you can get it 
 via web browser on `https://<openshift server>/oauth/token/request`
 
-#### providertlsverify
-If `providerapi` is using https protocol you can optionally
+#### provider-tlsverify
+If `provider-api` is using https protocol you can optionally
 disable verification of tls/ssl certificates. This can be especially
 useful when using self-signed certificates.
 
 ```
 [general]
 provider = openshift
-providerapi = https://127.0.0.1:8443
-accesstoken = sadfasdfasfasfdasfasfasdfsafasfd
+provider-api = https://127.0.0.1:8443
+provider-auth = sadfasdfasfasfdasfasfasdfsafasfd
 namespace = mynamespace
-providertlsverify = False
+provider-tlsverify = False
 ```
 
-**NOTE**: If `providerconfig` is used  values of `providertlsverify`
-and `providercafile` are set according to settings in `providerconfig` file.
+**NOTE**: If `provider-config` is used  values of `provider-tlsverify`
+and `provider-cafile` are set according to settings in `provider-config` file.
 
-#### providercafile
-If `providerapi` is using https protocol you can optionally specify
+#### provider-cafile
+If `provider-api` is using https protocol you can optionally specify
 path to a CA_BAUNDLE file or directory with certificates of trusted CAs.
 
-**NOTE**: If `providerconfig` is used  values of `providertlsverify`
-and `providercafile` are set according to settings in `providerconfig` file.
+**NOTE**: If `provider-config` is used  values of `provider-tlsverify`
+and `provider-cafile` are set according to settings in `provider-config` file.
 
 
 #### Configuration Value Defaults
@@ -103,15 +103,15 @@ Table 1. OpenShift default configuration values
 Keyword  | Required | Description                                             | Default value
 ---------|----------|---------------------------------------------------------|--------------
 namespace|   no     | namespace to use with each kubectl call                 | default
-providerconfig| no  | config file that specifies how to connect to kubernetes | none
-providerapi|  no    | the API endpoint where API requests can be sent         | none
-accesstoken|  no    | the access token that can be used to authenticate       | none
-providertlsverify|no| turn off verificatoin of tls/ssl certificates           | False
-providercafile| no  | path to file or directory with trusted CAs              | none
+provider-config| no  | config file that specifies how to connect to kubernetes | none
+provider-api|  no    | the API endpoint where API requests can be sent         | none
+provider-auth|  no    | the access token that can be used to authenticate       | none
+provider-tlsverify|no| turn off verificatoin of tls/ssl certificates           | False
+provider-cafile| no  | path to file or directory with trusted CAs              | none
 
-**NOTE**: One of `providerconfig` or `providerapi` + `accesstoken` are required
+**NOTE**: One of `provider-config` or `provider-api` + `provider-auth` are required
 
-**NOTE**: Namespace can be set in the file pointed to by `providerconfig` or 
+**NOTE**: Namespace can be set in the file pointed to by `provider-config` or 
 in the `answers.conf`. If it is set in both places then the values must match,
 or an error will be reported.
 

--- a/docs/providers/openshift/overview_native.md
+++ b/docs/providers/openshift/overview_native.md
@@ -20,7 +20,7 @@ from the environment of the installation container that is used to
 bootstrap the start of the application. It is not necessary to provide
 the namespace in the config.
 
-#### providerconfig / providerapi / access_token
+#### provider-config / provider-api / provider-auth
 
 At the time of execution, the Atomic App container is already running
 inside of the openshift environment and has access to the credentials


### PR DESCRIPTION
This commit modified the documentation within atomic app to reflect the
addition of dashes to separate provider config related information.