### PR TITLE
init: modify docker template to publish to host port 80

### DIFF
--- a/atomicapp/external/templates/nulecule/artifacts/docker/run.tpl
+++ b/atomicapp/external/templates/nulecule/artifacts/docker/run.tpl
@@ -1,1 +1,1 @@
-docker run -d --name $app_name -P $image
+docker run -d --name $app_name -p 80:80 $image


### PR DESCRIPTION
This should make it easier for a user to demo without having to figure
out what random port was assigned to be used.