### PR TITLE
Now logs can show path to file under root atomicapp folder

### DIFF
--- a/atomicapp/applogging.py
+++ b/atomicapp/applogging.py
@@ -27,15 +27,29 @@ from atomicapp.constants import (LOGGER_COCKPIT,
 class customOutputFormatter(logging.Formatter):
     """
     A class that adds 'longerfilename' support to the logging formatter
-    This 'longerfilename' will be filename + parent dir.
+    This 'longerfilename' will be path/to/file.py after the root atomicapp
+    folder.
     """
 
-    def format(self, record):
+    def __init__(self, *args):
+        super(customOutputFormatter, self).__init__(*args)
 
-        # Add the 'longerfilename' field to the record dict. This is
-        # then used by the Formatter in the logging library when
-        # formatting the message string.
-        record.longerfilename = '/'.join(record.pathname.split('/')[-2:])
+        # setting the root directory path of code base, currently this file is
+        # at /home/xyz/atomicapp/applogging.py so we need this path except for
+        # the 'applogging.py' so while splitting here, only last component
+        # i.e. 'applogging.py' is excluded by using -1, so if applogging.py
+        # is moved into another directory and if path becomes
+        # /home/xyz/atomicapp/logs/applogging.py to remove
+        # 'logs/applogging.py' use -2
+        self.atomicapproot = '/'.join(__file__.split('/')[:-1])
+
+    def format(self, record):
+        """
+        Add the 'longerfilename' field to the record dict. This is
+        then used by the Formatter in the logging library when
+        formatting the message string.
+        """
+        record.longerfilename = record.pathname.split(self.atomicapproot)[-1].lstrip('/')
 
         # Call the parent class to do formatting.
         return super(customOutputFormatter, self).format(record)


### PR DESCRIPTION
Earlier atomicapp in the logs would show only the directory + file that is being executed but this was nice when atomicapp was only two level deep in its directory structure. So this was not showing
the complete path after root atomicapp folder. But now it will show the complete path after root atomicapp folder.

Fixes #695