### PR TITLE
Abstracted the way we get absolute path

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -474,7 +474,7 @@ class CLI():
             if hasattr(args, item) and getattr(args, item) is not None:
                 args.cli_answers[item] = getattr(args, item)
 
-        lock = LockFile(os.path.join(Utils.getRoot(), LOCK_FILE))
+        lock = LockFile(Utils.get_real_abspath(LOCK_FILE))
         try:
             if args.action != 'init':
                 lock.acquire(timeout=-1)

--- a/atomicapp/nulecule/main.py
+++ b/atomicapp/nulecule/main.py
@@ -74,14 +74,11 @@ class NuleculeManager(object):
 
         # Adjust app_spec, destination, and answer file paths if absolute.
         if os.path.isabs(app_spec):
-            app_spec = os.path.join(Utils.getRoot(),
-                                    app_spec.lstrip('/'))
+            app_spec = Utils.get_real_abspath(app_spec)
         if destination and os.path.isabs(destination):
-            destination = os.path.join(Utils.getRoot(),
-                                       destination.lstrip('/'))
+            destination = Utils.get_real_abspath(destination)
         if answers_file and os.path.isabs(answers_file):
-            answers_file = os.path.join(Utils.getRoot(),
-                                        answers_file.lstrip('/'))
+            answers_file = Utils.get_real_abspath(answers_file)
 
         # If the user doesn't want the files copied to a permanent
         # location then he provides 'none'. If that is the case we'll

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -75,8 +75,7 @@ class Provider(object):
         if PROVIDER_CONFIG_KEY in self.config:
             self.config_file = self.config[PROVIDER_CONFIG_KEY]
             if os.path.isabs(self.config_file):
-                self.config_file = os.path.join(Utils.getRoot(),
-                                                self.config_file.lstrip('/'))
+                self.config_file = Utils.get_real_abspath(self.config_file)
         else:
             logger.warning("Configuration option '%s' not found" % PROVIDER_CONFIG_KEY)
 

--- a/atomicapp/providers/kubernetes.py
+++ b/atomicapp/providers/kubernetes.py
@@ -55,7 +55,7 @@ class KubernetesProvider(Provider):
         if self.container:
             self.kubectl = self._find_kubectl(Utils.getRoot())
             kube_conf_path = "/etc/kubernetes"
-            host_kube_conf_path = os.path.join(Utils.getRoot(), kube_conf_path.lstrip("/"))
+            host_kube_conf_path = Utils.get_real_abspath(kube_conf_path)
             if not os.path.exists(kube_conf_path) and os.path.exists(host_kube_conf_path):
                 if self.dryrun:
                     logger.info("DRY-RUN: link %s from %s" % (kube_conf_path, host_kube_conf_path))

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -680,8 +680,7 @@ class OpenShiftProvider(Provider):
         self.provider_tls_verify = result[PROVIDER_TLS_VERIFY_KEY]
         if result[PROVIDER_CA_KEY]:
             # if we are in container translate path to path on host
-            self.provider_ca = os.path.join(Utils.getRoot(),
-                                            result[PROVIDER_CA_KEY].lstrip('/'))
+            self.provider_ca = Utils.get_real_abspath(result[PROVIDER_CA_KEY])
         else:
             self.provider_ca = None
 

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -354,6 +354,21 @@ class Utils(object):
         else:
             return "/"
 
+    @staticmethod
+    def get_real_abspath(path):
+        """
+        Take the user provided 'path' and return the real path to the resource
+        irrespective of the app running location either inside container or
+        outside.
+
+        Args:
+            path (str): path to a resource
+
+        Returns:
+            str: absolute path to resource in the filesystem.
+        """
+        return os.path.join(Utils.getRoot(), path.lstrip('/'))
+
     # generates a unique 12 character UUID
     @staticmethod
     def getUniqueUUID():


### PR DESCRIPTION
Added a `staticmethod` in `utils.Utils` named `get_abspath` which abstracts the use of `os.path.join(Utils.getRoot, path)`