### PR TITLE
Remove dockerenv and dockerinit check

### DIFF
--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -342,7 +342,7 @@ class Utils(object):
         Returns:
             (bool): True == we are in a container
         """
-        if os.path.isfile('/.dockerenv') and os.path.isfile('/.dockerinit') and os.path.isdir(HOST_DIR):
+        if os.path.isdir(HOST_DIR):
             return True
         else:
             return False


### PR DESCRIPTION
Found this out when using Docker 1.11

.dockerenv and .dockerinit files have been removed in 1.10 of Docker due
to not using the LXC built-in exec driver anymore and thus the files no
longer appear within Atomic App and fail to pick up whether or not we
are running in a container or not.

See: https://docs.docker.com/engine/deprecated/
```
LXC built-in exec driver
Deprecated In Release: v1.8

Target For Removal In Release: v1.10

The built-in LXC execution driver is deprecated for an external
implementation. The lxc-conf flag and API fields will also be removed.
```