### PR TITLE
Add a new 'library' for k8s/openshift providers.

### DIFF
--- a/atomicapp/constants.py
+++ b/atomicapp/constants.py
@@ -75,6 +75,8 @@ PROVIDER_CONFIG_KEY = "provider-config"
 PROVIDER_TLS_VERIFY_KEY = "provider-tlsverify"
 PROVIDER_CA_KEY = "provider-cafile"
 
+K8S_DEFAULT_API = "http://localhost:8080"
+
 # Persistent Storage Formats
 PERSISTENT_STORAGE_FORMAT = ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]
 

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -40,7 +40,9 @@ class Provider(object):
     dryrun = None
     container = False
     config_file = None
-    __artifacts = None
+
+    # By default, no artifacts are loaded
+    __artifacts = []
 
     @property
     def artifacts(self):

--- a/atomicapp/providers/lib/kubeshift/client.py
+++ b/atomicapp/providers/lib/kubeshift/client.py
@@ -1,0 +1,57 @@
+"""
+ Copyright 2014-2016 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from atomicapp.providers.lib.kubeshift.kubernetes import KubeKubernetesClient
+from atomicapp.providers.lib.kubeshift.exceptions import KubeClientError
+from atomicapp.constants import LOGGER_DEFAULT
+import logging
+logger = logging.getLogger(LOGGER_DEFAULT)
+
+
+class Client(object):
+
+    def __init__(self, config, provider):
+        '''
+
+        Args:
+            config (obj): Object of the configuration data
+            provider (str): String value of the provider that is being used
+
+        '''
+        self.config = config
+        self.provider = provider
+
+        # Choose the type of provider that is being used. Error out if it is not available
+        if provider is "kubernetes":
+            self.connection = KubeKubernetesClient(config)
+            logger.debug("Using Kubernetes Provider KubeClient library")
+        else:
+            raise KubeClientError("No provider by that name.")
+
+    # Create an object using its respective API
+    def create(self, obj, namespace="default"):
+        self.connection.create(obj, namespace)
+
+    # Delete an object using its respective API
+    def delete(self, obj, namespace="default"):
+        self.connection.delete(obj, namespace)
+
+    # Current support: kubernetes only
+    def namespaces(self):
+        return self.connection.namespaces()

--- a/atomicapp/providers/lib/kubeshift/exceptions.py
+++ b/atomicapp/providers/lib/kubeshift/exceptions.py
@@ -1,0 +1,42 @@
+"""
+ Copyright 2014-2016 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+class KubeOpenshiftError(Exception):
+    pass
+
+
+class KubeKubernetesError(Exception):
+    pass
+
+
+class KubeConfigError(Exception):
+    pass
+
+
+class KubeClientError(Exception):
+    pass
+
+
+class KubeConnectionError(Exception):
+    pass
+
+
+class KubeBaseError(Exception):
+    pass

--- a/atomicapp/providers/lib/kubeshift/kubebase.py
+++ b/atomicapp/providers/lib/kubeshift/kubebase.py
@@ -1,0 +1,341 @@
+"""
+ Copyright 2014-2016 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import requests
+import websocket
+import tempfile
+import base64
+import ssl
+from requests.exceptions import SSLError
+from atomicapp.providers.lib.kubeshift.exceptions import (KubeBaseError,
+                                                          KubeConnectionError)
+from atomicapp.constants import LOGGER_DEFAULT
+import logging
+logger = logging.getLogger(LOGGER_DEFAULT)
+
+
+class KubeBase(object):
+
+    '''
+    The role of Kube Base is to parse the Kube Config file and create an
+    understandable API as well as initiation of connection to
+    Kubernetes-based APIs (OpenShift/Kubernetes).
+
+    '''
+    cluster = None
+    user = None
+    token = None
+    client_certification = None
+    client_key = None
+    certificate_authority_data = None  # Not yet implemented
+    certificate_authority = None
+    certificate_ca = None  # Not yet implemented
+    insecure_skip_tls_verify = False
+
+    def __init__(self, config):
+        '''
+        Args:
+            config (object): An object of the .kube/config configuration
+        '''
+        self.kubeconfig = config
+
+        # Gather the "current-context" from .kube/config which lists what the
+        # associated cluster, user, token, etc. is being used.
+        if "current-context" not in config:
+            raise KubeBaseError("'current-context' needs to be set within .kube/config")
+        else:
+            self.current_context = config["current-context"]
+
+        # Gather the context and cluster details of .kube/config based upon the current_context
+        kubeconfig_context = self._contexts()[self.current_context]
+        kubeconfig_cluster = kubeconfig_context['cluster']
+        self.cluster = self._clusters()[kubeconfig_cluster]
+
+        # Gather cluster information (certificate authority)
+        if "certificate-authority" in self.cluster:
+            self.certificate_authority = self.cluster["certificate-authority"]
+
+        if "insecure-skip-tls-verify" in self.cluster:
+            self.insecure_skip_tls_verify = self.cluster["insecure-skip-tls-verify"]
+
+        # If a 'user' is present, gather the information in order to retrieve the token(s),
+        # certificate(s) as well as client-key. A user is OPTIONAL in the .kube/config data
+        # and hence the if statement.
+        if "user" in kubeconfig_context:
+
+            kubeconfig_user = kubeconfig_context['user']
+            self.user = self._users()[kubeconfig_user]
+
+            if "token" in self.user:
+                self.token = self.user['token']
+
+            if "client-certificate" in self.user:
+                self.client_certification = self.user['client-certificate']
+
+            if "client-key" in self.user:
+                self.client_key = self.user['client-key']
+
+        # Initialize the connection using all the .kube/config credentials
+        self.api = self._connection()
+
+    def request(self, method, url, data=None):
+        '''
+        Completes the request to the API and fails if the status_code is != 200/201
+
+        Args:
+            method (str): put/get/post/patch
+            url (str): url of the api call
+            data (object): object of the data that is being passed (will be converted to json)
+        '''
+        status_code = None
+        return_data = None
+
+        try:
+            res = self._request_method(method, url, data)
+            status_code = res.status_code
+            return_data = res.json()
+        except requests.exceptions.ConnectTimeout:
+            msg = "Timeout when connecting to  %s" % url
+            raise KubeConnectionError(msg)
+        except requests.exceptions.ReadTimeout:
+            msg = "Timeout when reading from %s" % url
+            raise KubeConnectionError(msg)
+        except requests.exceptions.ConnectionError:
+            msg = "Refused connection to %s" % url
+            raise KubeConnectionError(msg)
+        except SSLError:
+            raise KubeConnectionError("SSL/TLS ERROR: invalid certificate")
+        except ValueError:
+            return_data = None
+
+        # 200 = OK
+        # 201 = PENDING
+        # EVERYTHING ELSE == FAIL
+        if status_code is not 200 and status_code is not 201:
+            raise KubeConnectionError("Unable to complete request: Status: %s, Error: %s"
+                                      % (status_code, return_data))
+        return return_data
+
+    def websocket_request(self, url, outfile=None):
+        '''
+        Due to the requests library not supporting SPDY, websocket(s) are required
+        to communicate to the API.
+
+        Args:
+            url (str): URL of the API
+            outfile (str): path of the outfile/data.
+        '''
+        url = 'wss://' + url.split('://', 1)[-1]
+        logger.debug('Converted http to wss url: {}'.format(url))
+        results = []
+
+        ws = websocket.WebSocketApp(
+            url,
+            on_message=lambda ws, message: self._handle_exec_reply(ws, message, results, outfile))
+
+        ws.run_forever(sslopt={
+            'ca_certs': self.cert_ca if self.cert_ca is not None else ssl.CERT_NONE,
+            'cert_reqs': ssl.CERT_REQUIRED if self.insecure_skip_tls_verify else ssl.CERT_NONE})
+
+        # If an outfile was not provided, return the results in its entirety
+        if not outfile:
+            return ''.join(results)
+
+    def get_resources(self, url):
+        '''
+        Get the resources available to the API. This is a list of all available
+        API calls that can be made to the API.
+        '''
+        data = self.request("get", url)
+        resources = data["resources"]
+        resources = [res['name'] for res in resources]
+        return resources
+
+    def test_connection(self, url):
+        self.api.request("get", url)
+        logger.debug("Connection successfully tested")
+
+    @staticmethod
+    def cert_file(data, key):
+        '''
+        Some certificate .kube/config components are required to be a filename.
+
+        Returns either the filename or a tmp location of said data in a file.
+        All certificates used with Kubernetes are base64 encoded and thus need to be decoded
+
+        Keys which have "-data" associated with the name are base64 encoded. All others are not.
+        '''
+
+        # If it starts with /, we assume it's a filename so we just return that.
+        if data.startswith('/'):
+            return data
+
+        # If it's data, we assume it's a certificate and we decode and write to a tmp file
+        # If the base64 param has been passed as true, we decode the data.
+        else:
+            with tempfile.NamedTemporaryFile(delete=False) as f:
+                # If '-data' is included in the keyname, it's a base64 encoded string and
+                # is required to be decoded
+                if "-data" in key:
+                    f.write(base64.b64decode(data))
+                else:
+                    f.write(data)
+                return f.name
+
+    @staticmethod
+    def kind_to_resource_name(kind):
+        """
+        Converts kind to resource name. It is same logics
+        as in k8s.io/k8s/pkg/api/meta/restmapper.go (func KindToResource)
+        Example:
+            Pod -> pods
+            Policy - > policies
+            BuildConfig - > buildconfigs
+
+        Args:
+            kind (str): Kind of the object
+
+        Returns:
+            Resource name (str) (kind in plural form)
+        """
+        singular = kind.lower()
+        if singular.endswith("status"):
+            plural = singular + "es"
+        else:
+            if singular[-1] == "s":
+                plural = singular
+            elif singular[-1] == "y":
+                plural = singular.rstrip("y") + "ies"
+            else:
+                plural = singular + "s"
+        return plural
+
+    def _contexts(self):
+        '''
+        Parses the contexts and formats it in a name = object way.
+        ex.
+            'foobar': { name: 'foobar', context: 'foo' }
+        '''
+        contexts = {}
+        if "contexts" not in self.kubeconfig:
+            raise KubeBaseError("No contexts within the .kube/config file")
+        for f in self.kubeconfig["contexts"]:
+            contexts[f["name"]] = f["context"]
+        return contexts
+
+    def _clusters(self):
+        '''
+        Parses the clusters and formats it in a name = object way.
+        ex.
+            'foobar': { name: 'foobar', cluster: 'foo' }
+        '''
+        clusters = {}
+        if "clusters" not in self.kubeconfig:
+            raise KubeBaseError("No clusters within the .kube/config file")
+        for f in self.kubeconfig["clusters"]:
+            clusters[f["name"]] = f["cluster"]
+        return clusters
+
+    def _users(self):
+        '''
+        Parses the users and formats it in a name = object way.
+        ex.
+            'foobar': { name: 'foobar', user: 'foo' }
+        '''
+        users = {}
+        if "users" not in self.kubeconfig:
+            raise KubeBaseError("No users within the .kube/config file")
+        for f in self.kubeconfig["users"]:
+            users[f["name"]] = f["user"]
+        return users
+
+    def _connection(self):
+        '''
+        Initializes the required requests session certs / token / authentication
+        in order to communicate with the API
+        '''
+        connection = requests.Session()
+
+        # CA Certificate for TLS verification
+        if self.certificate_authority:
+            connection.verify = self.cert_file(
+                self.certificate_authority,
+                "certificate-authority")
+
+        # Check to see if verification has been disabled, if it has
+        # disable tls-verification
+        if self.insecure_skip_tls_verify:
+            connection.verify = False
+            # Disable the 'InsecureRequestWarning' notifications.
+            # As per: https://github.com/kennethreitz/requests/issues/2214
+            # Instead make a large one-time noticable warning instead
+            requests.packages.urllib3.disable_warnings()
+            logger.warning("CAUTION: TLS verification has been DISABLED")
+        else:
+            logger.debug("Verification will be required for all API calls")
+
+        # If we're using a token, use it, otherwise it's assumed the user uses
+        # client-certificate and client-key
+        if self.token:
+            connection.headers["Authorization"] = "Bearer %s" % self.token
+
+        # Lastly, if we have client-certificate and client-key in the .kube/config
+        # we add them to the connection as a cert
+        if self.client_certification and self.client_key:
+            connection.cert = (
+                self.cert_file(self.client_certification, "client-certificate"),
+                self.cert_file(self.client_key, "client-key")
+            )
+
+        return connection
+
+    def _handle_ws_reply(self, ws, message, results, outfile=None):
+        """
+        Handle websocket reply messages for each exec call
+        """
+        # FIXME: For some reason, we do not know why,  we need to ignore the
+        # 1st char of the message, to generate a meaningful result
+        cleaned_msg = message[1:]
+        if outfile:
+            with open(outfile, 'ab') as f:
+                f.write(cleaned_msg)
+        else:
+            results.append(cleaned_msg)
+
+    def _request_method(self, method, url, data):
+        '''
+        Converts the method to the most appropriate request and calls it.
+
+        Args:
+            method (str): put/get/post/patch
+            url (str): url of the api call
+            data (object): object of the data that is being passed (will be converted to json)
+        '''
+        if method.lower() == "get":
+            res = self.api.get(url)
+        elif method.lower() == "post":
+            res = self.api.post(url, json=data)
+        elif method.lower() == "put":
+            res = self.api.put(url, json=data)
+        elif method.lower() == "delete":
+            res = self.api.delete(url, json=data)
+        elif method.lower() == "patch":
+            headers = {"Content-Type": "application/json-patch+json"}
+            res = self.api.patch(url, json=data, headers=headers)
+        return res

--- a/atomicapp/providers/lib/kubeshift/kubeconfig.py
+++ b/atomicapp/providers/lib/kubeshift/kubeconfig.py
@@ -14,6 +14,70 @@ logger = logging.getLogger(LOGGER_DEFAULT)
 class KubeConfig(object):
 
     @staticmethod
+    def from_file(filename):
+        '''
+        Load a file using anymarkup
+
+        Params:
+            filename (str): File location
+        '''
+
+        return anymarkup.parse_file(filename)
+
+    @staticmethod
+    def from_params(api=None, auth=None, ca=None, verify=True):
+        '''
+        Creates a .kube/config configuration as an
+        object based upon the arguments given.
+
+        Params:
+            api(str): API URL of the server
+            auth(str): Authentication key for the server
+            ca(str): The certificate being used. This can be either a file location or a base64 encoded string
+            verify(bool): true/false of whether or not certificate verification is enabled
+
+        Returns:
+            config(obj): An object file of generate .kube/config
+
+        '''
+        config = {
+            "clusters": [
+                {
+                    "name": "self",
+                    "cluster": {
+                    },
+                },
+            ],
+            "users": [
+                {
+                    "name": "self",
+                    "user": {
+                        "token": ""
+                    },
+                },
+            ],
+            "contexts": [
+                {
+                    "name": "self",
+                    "context": {
+                        "cluster": "self",
+                        "user": "self",
+                    },
+                }
+            ],
+            "current-context": "self",
+        }
+        if api:
+            config['clusters'][0]['cluster']['server'] = api
+
+        if auth:
+            config['users'][0]['user']['token'] = auth
+
+        if ca:
+            config['clusters'][0]['cluster']['certificate-authority'] = ca
+        return config
+
+    @staticmethod
     def parse_kubeconf(filename):
         """"
         Parse kubectl config file

--- a/atomicapp/providers/lib/kubeshift/kubernetes.py
+++ b/atomicapp/providers/lib/kubeshift/kubernetes.py
@@ -1,0 +1,171 @@
+"""
+ Copyright 2014-2016 Red Hat, Inc.
+
+ This file is part of Atomic App.
+
+ Atomic App is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Atomic App is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with Atomic App. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from urlparse import urljoin
+from urllib import urlencode
+from atomicapp.providers.lib.kubeshift.kubebase import KubeBase
+from atomicapp.providers.lib.kubeshift.exceptions import (KubeKubernetesError)
+from atomicapp.constants import LOGGER_DEFAULT
+import logging
+import re
+logger = logging.getLogger(LOGGER_DEFAULT)
+
+
+class KubeKubernetesClient(object):
+
+    def __init__(self, config):
+        '''
+
+        Args:
+            config (obj): Object of the configuration data
+
+        '''
+
+        # Pass in the configuration data (.kube/config object) to the KubeBase
+        self.api = KubeBase(config)
+
+        # Check the API url
+        url = self.api.cluster['server']
+        if not re.match('(?:http|https)://', url):
+            raise KubeKubernetesError("Kubernetes API URL does not include HTTP or HTTPS")
+
+        # Gather what end-points we will be using
+        self.k8s_api = urljoin(url, "api/v1/")
+
+        # Test the connection before proceeding
+        self.api.test_connection(self.k8s_api)
+
+        # Gather the resource names which will be used for the 'kind' API calls
+        self.k8s_api_resources = self.api.get_resources(self.k8s_api)
+
+    def create(self, obj, namespace):
+        '''
+        Create an object from the Kubernetes cluster
+        '''
+        name = self._get_metadata_name(obj)
+        kind, url = self._generate_kurl(obj, namespace)
+        self.api.request("post", url, data=obj)
+        logger.info("%s '%s' successfully created" % (kind.capitalize(), name))
+
+    def delete(self, obj, namespace):
+        '''
+        Delete an object from the Kubernetes cluster
+
+        Args:
+            obj (object): Object of the artifact being modified
+            namesapce (str): Namespace of the kubernetes cluster to be used
+            replicates (int): Default 0, size of the amount of replicas to scale
+
+        *Note*
+        Replication controllers must scale to 0 in order to delete pods.
+        Kubernetes 1.3 will implement server-side cascading deletion, but
+        until then, it's mandatory to scale to 0
+        https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/garbage-collection.md
+
+        '''
+        name = self._get_metadata_name(obj)
+        kind, url = self._generate_kurl(obj, namespace, name)
+
+        if kind in ['rcs', 'replicationcontrollers']:
+            self.scale(obj, namespace)
+
+        self.api.request("delete", url)
+        logger.info("%s '%s' successfully deleted" % (kind.capitalize(), name))
+
+    def scale(self, obj, namespace, replicas=0):
+        '''
+        By default we scale back down to 0. This function takes an object and scales said
+        object down to a specified value on the Kubernetes cluster
+
+        Args:
+            obj (object): Object of the artifact being modified
+            namesapce (str): Namespace of the kubernetes cluster to be used
+            replicates (int): Default 0, size of the amount of replicas to scale
+        '''
+        patch = [{"op": "replace",
+                  "path": "/spec/replicas",
+                  "value": replicas}]
+        name = self._get_metadata_name(obj)
+        _, url = self._generate_kurl(obj, namespace, name)
+        self.api.request("patch", url, data=patch)
+        logger.info("'%s' successfully scaled to %s" % (name, replicas))
+
+    def namespaces(self):
+        '''
+        Gathers a list of namespaces on the Kubernetes cluster
+        '''
+        url = urljoin(self.k8s_api, "namespaces")
+        ns = self.api.request("get", url)
+        return ns['items']
+
+    def _generate_kurl(self, obj, namespace, name=None, params=None):
+        '''
+        Generate the required URL by extracting the 'kind' from the
+        object as well as the namespace.
+
+        Args:
+            obj (obj): Object of the data being passed
+            namespace (str): k8s namespace
+            name (str): Name of the object being passed
+            params (arr): Extra params passed such as timeout=300
+
+        Returns:
+            kind (str): The kind used
+            url (str): The URL to be used / artifact URL
+        '''
+        if 'kind' not in obj.keys():
+            raise KubeKubernetesError("Error processing object. There is no kind")
+
+        kind = obj['kind']
+
+        resource = KubeBase.kind_to_resource_name(kind)
+
+        if resource in self.k8s_api_resources:
+            url = self.k8s_api
+        else:
+            raise KubeKubernetesError("No kind by that name: %s" % kind)
+
+        url = urljoin(url, "namespaces/%s/%s/" % (namespace, resource))
+
+        if name:
+            url = urljoin(url, name)
+
+        if params:
+            url = urljoin(url, "?%s" % urlencode(params))
+
+        return (resource, url)
+
+    def _get_metadata_name(self, obj):
+        '''
+        This looks at the object and grabs the metadata name of said object
+
+        Args:
+            obj (object): Object file of the artifact
+
+        Returns:
+            name (str): Returns the metadata name of the object
+        '''
+        if "metadata" in obj and \
+                "name" in obj["metadata"]:
+            name = obj["metadata"]["name"]
+        else:
+            raise KubeKubernetesError("Cannot undeploy. There is no"
+                                      " name in object metadata "
+                                      "object=%s" % obj)
+        return name

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -39,7 +39,7 @@ from atomicapp.constants import (PROVIDER_AUTH_KEY,
                                  PROVIDER_TLS_VERIFY_KEY,
                                  PROVIDER_CA_KEY,
                                  OPENSHIFT_POD_CA_FILE)
-from atomicapp.providers.lib.kubeconfig import KubeConfig
+from atomicapp.providers.lib.kubeshift.kubeconfig import KubeConfig
 from requests.exceptions import SSLError
 import logging
 logger = logging.getLogger(LOGGER_DEFAULT)

--- a/tests/units/nulecule/test_kubeconfig.py
+++ b/tests/units/nulecule/test_kubeconfig.py
@@ -1,6 +1,6 @@
 import unittest
 from atomicapp.plugin import ProviderFailedException
-from atomicapp.providers.lib.kubeconfig import KubeConfig
+from atomicapp.providers.lib.kubeshift.kubeconfig import KubeConfig
 
 
 class TestKubeConfParsing(unittest.TestCase):

--- a/tests/units/providers/test_kubernetes_provider.py
+++ b/tests/units/providers/test_kubernetes_provider.py
@@ -28,9 +28,6 @@ from atomicapp.providers.kubernetes import KubernetesProvider
 
 MOCK_CONTENT = "mock_provider_call_content"
 
-def mock_provider_call(self, cmd):
-    return MOCK_CONTENT
-
 class TestKubernetesProviderBase(unittest.TestCase):
 
     # Create a temporary directory for our setup as well as load the required providers
@@ -53,7 +50,6 @@ class TestKubernetesProviderBase(unittest.TestCase):
         return provider
 
     # Check that the provider configuration file exists
-    @mock.patch.object(KubernetesProvider, '_call', mock_provider_call)
     def test_provider_config_exist(self):
         provider_config_path = self.create_temp_file()
         mock_content = "%s_%s" % (MOCK_CONTENT, "_unchanged")


### PR DESCRIPTION
This is the first commit and first initialization into refactoring the
OpenShift provider in order to create a library that is both compatible
with OpenShift as well as Kubernetes.

With this 'library', the *ONLY* thing that is passed in is an object of
the .kube/config configuration. After passing the configuration, you may
make API calls such as .create(object) and .delete(object).

This commit integrates the library as well as converts the current Kubernetes provider from cmd-line (using kubectl) to using the API.