### PR TITLE
Change provider-config warning to debug

### DIFF
--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -77,7 +77,7 @@ class Provider(object):
             if os.path.isabs(self.config_file):
                 self.config_file = Utils.get_real_abspath(self.config_file)
         else:
-            logger.warning("Configuration option '%s' not found" % PROVIDER_CONFIG_KEY)
+            logger.debug("Configuration option '%s' not provided" % PROVIDER_CONFIG_KEY)
 
     def checkConfigFile(self):
         if not self.config_file:


### PR DESCRIPTION
This should be within the debug log rather than warn the user.
Basically, if the user has not provided --provider-config Atomic App
will warn. This should instead be put in the debugging output to let the
developer know that --provider-config hasn't been passed via
answers.conf or the CLI.