### PR TITLE
Remove README.MD from init

### DIFF
--- a/atomicapp/external/templates/nulecule/README.md.tpl
+++ b/atomicapp/external/templates/nulecule/README.md.tpl
@@ -1,3 +1,0 @@
-# $app_name Atomic App
-
-My awesome Atomic App.


### PR DESCRIPTION
Init should be clean and thus no README.md should be provided. Some
people use pandoc, ascii, etc.

ping @rtnpro