### PR TITLE
Add binary generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,12 +26,16 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+bin/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+
+# Don't ignore atomicapp.spec for PyInstaller builds
+!atomicapp.spec
 
 # Installer logs
 pip-log.txt

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ syntax-check:
 .PHONY: clean
 clean:
 	$(PYTHON) setup.py clean --all
+
+.PHONY: binary
+binary:
+	./script/binary.sh

--- a/atomicapp.spec
+++ b/atomicapp.spec
@@ -1,0 +1,57 @@
+# -*- mode: python -*-
+
+# Function in order to recursively add data directories to pyinstaller
+def extra_datas(mydir):
+    def rec_glob(p, files):
+        import os
+        import glob
+        for d in glob.glob(p):
+            if os.path.isfile(d):
+                files.append(d)
+            rec_glob("%s/*" % d, files)
+    files = []
+    rec_glob("%s/*" % mydir, files)
+    extra_datas = []
+    for f in files:
+        extra_datas.append((f, f, 'DATA'))
+
+    return extra_datas
+
+block_cipher = None
+
+# Due to the way that we dynamically load providers via import_module
+# in atomicapp/plugin.py we have to specify explicitly the modules directly
+# so pyinstaller can "see" them. This is indicated by 'hiddenimports'
+a = Analysis(['atomicapp/cli/main.py'],
+             pathex=['.'],
+             binaries=None,
+             datas=None,
+             hiddenimports=[
+               'atomicapp.providers.docker', 
+               'atomicapp.providers.kubernetes',
+               'atomicapp.providers.openshift',
+               'atomicapp.providers.marathon'
+             ],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+
+# Add external data (atomicapp init + provider external data)
+a.datas += extra_datas('atomicapp/providers/external')
+a.datas += extra_datas('atomicapp/nulecule/external')
+
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='atomicapp/cli/main',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )

--- a/script/binary.sh
+++ b/script/binary.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+pip install -r requirements.txt
+pip install pyinstaller
+
+# Due to the way that we dynamically load providers via import_module
+# in atomicapp/plugin.py we have to specify explicitly the modules directly
+# so pyinstaller can "see" them.
+pyinstaller atomicapp.spec
+
+mkdir -p bin
+mv dist/main bin/atomicapp
+echo "Binary created at bin/atomicapp"


### PR DESCRIPTION
This commit adds the command `make binary` to generate a binary using
pyinstaller.

This generates a stand-alone executable that will work on any operating
system even if it doesn't have Python installed.

Having a binary would allow us to create a minimal container >10MB
without the need of relying on the underlying operating system.