### PR TITLE
Removes loading via .py files

### DIFF
--- a/atomicapp/nulecule/base.py
+++ b/atomicapp/nulecule/base.py
@@ -44,7 +44,7 @@ from atomicapp.requirements import Requirements
 from atomicapp.nulecule.lib import NuleculeBase
 from atomicapp.nulecule.container import DockerHandler
 from atomicapp.nulecule.exceptions import NuleculeException
-from atomicapp.providers.openshift import OpenShiftProvider
+from atomicapp.providers.openshift import OpenshiftProvider
 
 from jsonpointer import resolve_pointer, set_pointer, JsonPointerException
 from anymarkup import AnyMarkupError
@@ -115,7 +115,7 @@ class Nulecule(NuleculeBase):
         if Utils.running_on_openshift():
             # pass general config data containing provider specific data
             # to Openshift provider
-            op = OpenShiftProvider(config.get('general', {}), './', False)
+            op = OpenshiftProvider(config.get('general', {}), './', False)
             op.artifacts = []
             op.init()
             op.extract(image, APP_ENT_PATH, dest, update)

--- a/atomicapp/nulecule/lib.py
+++ b/atomicapp/nulecule/lib.py
@@ -41,7 +41,6 @@ class NuleculeBase(object):
 
     def __init__(self, basepath, params, namespace):
         self.plugin = Plugin()
-        self.plugin.load_plugins()
         self.basepath = basepath
         self.params = params or []
         self.namespace = namespace

--- a/atomicapp/plugin.py
+++ b/atomicapp/plugin.py
@@ -22,9 +22,8 @@
 from __future__ import print_function
 import os
 
-import imp
-
 import logging
+import importlib
 from utils import Utils
 from constants import (HOST_DIR,
                        LOGGER_DEFAULT,
@@ -126,42 +125,11 @@ class Plugin(object):
     def __init__(self, ):
         pass
 
-    def load_plugins(self):
-        run_path = os.path.dirname(os.path.realpath(__file__))
-        providers_dir = os.path.join(run_path, "providers")
-        logger.debug("Loading providers from %s", providers_dir)
-
-        plugin_classes = {}
-        plugin_class = globals()["Provider"]
-
-        for f in os.listdir(providers_dir):
-            if f.endswith(".py"):
-                module_name = os.path.basename(f).rsplit('.', 1)[0]
-                try:
-                    f_module = imp.load_source(
-                        module_name, os.path.join(providers_dir, f))
-                except (IOError, OSError, ImportError) as ex:
-                    logger.warning("can't load module '%s': %s", f, repr(ex))
-                    continue
-
-                for name in dir(f_module):
-                    binding = getattr(f_module, name, None)
-                    try:
-                        # if you try to compare binding and PostBuildPlugin, python won't match them if you call
-                        # this script directly b/c:
-                        # ! <class 'plugins.plugin_rpmqa.PostBuildRPMqaPlugin'> <= <class '__main__.PostBuildPlugin'>
-                        # but
-                        # <class 'plugins.plugin_rpmqa.PostBuildRPMqaPlugin'> <= <class 'dock.plugin.PostBuildPlugin'>
-                        is_sub = issubclass(binding, plugin_class)
-                    except TypeError:
-                        is_sub = False
-                    if binding and is_sub and plugin_class.__name__ != binding.__name__:
-                        plugin_classes[binding.key] = binding
-
-        self.plugins = plugin_classes
-
     def getProvider(self, provider_key):
-        for key, provider in self.plugins.iteritems():
-            if key == provider_key:
-                logger.debug("Found provider %s", provider)
-                return provider
+        try:
+            module = importlib.import_module("atomicapp.providers.%s" % provider_key)
+            provider_class = "%sProvider" % provider_key.capitalize()
+            provider = getattr(module, provider_class)
+        except ImportError:
+            provider = None
+        return provider

--- a/atomicapp/providers/marathon.py
+++ b/atomicapp/providers/marathon.py
@@ -31,7 +31,7 @@ cockpit_logger = logging.getLogger(LOGGER_COCKPIT)
 logger = logging.getLogger(LOGGER_DEFAULT)
 
 
-class Marathon(Provider):
+class MarathonProvider(Provider):
 
     key = "marathon"
     config_file = None

--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -313,7 +313,7 @@ class OpenshiftClient(object):
         return return_data['status']['phase'].lower()
 
 
-class OpenShiftProvider(Provider):
+class OpenshiftProvider(Provider):
     key = "openshift"
     cli_str = "oc"
     cli = None

--- a/atomicapp/requirements.py
+++ b/atomicapp/requirements.py
@@ -44,7 +44,6 @@ class Requirements:
 
     def __init__(self, config, basepath, graph, provider, dryrun):
         self.plugin = Plugin()
-        self.plugin.load_plugins()
 
         self.config = config
         self.basepath = basepath

--- a/tests/units/providers/test_openshift_provider.py
+++ b/tests/units/providers/test_openshift_provider.py
@@ -9,23 +9,23 @@ the external world openshift and kubernetes API.
 
 import unittest
 import mock
-from atomicapp.providers.openshift import OpenShiftProvider
+from atomicapp.providers.openshift import OpenshiftProvider
 from atomicapp.plugin import ProviderFailedException
 
 
 class OpenshiftProviderTestMixin(object):
 
     def setUp(self):
-        # Patch OpenshiftClient to test OpenShiftProvider
+        # Patch OpenshiftClient to test OpenshiftProvider
         self.patcher = mock.patch('atomicapp.providers.openshift.OpenshiftClient')
         self.mock_OpenshiftClient = self.patcher.start()
         self.mock_oc = self.mock_OpenshiftClient()
 
     def get_oc_provider(self, dryrun=False, artifacts=[]):
         """
-        Get OpenShiftProvider instance
+        Get OpenshiftProvider instance
         """
-        op = OpenShiftProvider({}, '.', dryrun)
+        op = OpenshiftProvider({}, '.', dryrun)
         op.artifacts = artifacts
         op.access_token = 'test'
         op.init()
@@ -37,12 +37,12 @@ class OpenshiftProviderTestMixin(object):
 
 class TestOpenshiftProviderDeploy(OpenshiftProviderTestMixin, unittest.TestCase):
     """
-    Test OpenShiftProvider.run
+    Test OpenshiftProvider.run
     """
 
     def test_run(self):
         """
-        Test calling OpenshiftClient.run from OpenShiftProvider.run
+        Test calling OpenshiftClient.run from OpenshiftProvider.run
         """
         op = self.get_oc_provider()
         op.oapi_resources = ['foo']
@@ -64,7 +64,7 @@ class TestOpenshiftProviderDeploy(OpenshiftProviderTestMixin, unittest.TestCase)
 
     def test_run_dryrun(self):
         """
-        Test running OpenShiftProvider.run as dryrun
+        Test running OpenshiftProvider.run as dryrun
         """
         op = self.get_oc_provider(dryrun=True)
         op.oapi_resources = ['foo']
@@ -84,12 +84,12 @@ class TestOpenshiftProviderDeploy(OpenshiftProviderTestMixin, unittest.TestCase)
 
 class TestOpenshiftProviderUnrun(OpenshiftProviderTestMixin, unittest.TestCase):
     """
-    Test OpenShiftProvider.stop
+    Test OpenshiftProvider.stop
     """
 
     def test_stop(self):
         """
-        Test calling OpenshiftClient.delete from OpenShiftProvider.stop
+        Test calling OpenshiftClient.delete from OpenshiftProvider.stop
         """
         op = self.get_oc_provider()
         op.oapi_resources = ['foo']
@@ -113,7 +113,7 @@ class TestOpenshiftProviderUnrun(OpenshiftProviderTestMixin, unittest.TestCase):
 
     def test_stop_dryrun(self):
         """
-        Test running OpenShiftProvider.stop as dryrun
+        Test running OpenshiftProvider.stop as dryrun
         """
         op = self.get_oc_provider(dryrun=True)
         op.oapi_resources = ['foo']

--- a/tests/units/test_plugin.py
+++ b/tests/units/test_plugin.py
@@ -2,6 +2,8 @@ import mock
 import unittest
 
 from atomicapp.plugin import Plugin
+from atomicapp.providers.docker import DockerProvider
+from atomicapp.providers.kubernetes import KubernetesProvider
  
 class TestPluginGetProvider(unittest.TestCase):
  
@@ -13,8 +15,8 @@ class TestPluginGetProvider(unittest.TestCase):
         """
         p = Plugin()
        
-        docker_mock = mock.Mock()
-        kubernetes_mock = mock.Mock()
+        docker_mock = DockerProvider
+        kubernetes_mock = KubernetesProvider
         # keep some mock objects in place of the actual corresponding
         # classes, getProvider reads from `plugins` dict.
         p.plugins = {
@@ -23,5 +25,6 @@ class TestPluginGetProvider(unittest.TestCase):
         }
         self.assertEqual(p.getProvider('docker'), docker_mock)
         self.assertEqual(p.getProvider('kubernetes'), kubernetes_mock)
+
         # if non-existent key provided
         self.assertEqual(p.getProvider('some_random'), None)


### PR DESCRIPTION
The old code dynamically loaded providers/ .py files in order for the
user to dynamically add providers when need be.

Due to changes to Atomic App, we no longer require this and using a
provider is explicitly implied now on the command line.

This removes the work previously done in favour of loading modules via
the provider_key name.