### PR TITLE
more inclusive rules for adding 'es'

### DIFF
--- a/atomicapp/providers/lib/kubeshift/kubebase.py
+++ b/atomicapp/providers/lib/kubeshift/kubebase.py
@@ -224,7 +224,7 @@ class KubeBase(object):
             Resource name (str) (kind in plural form)
         """
         singular = kind.lower()
-        if singular.endswith("status"):
+        if singular.endswith(("s", "x", "z", "ch", "sh")):
             plural = singular + "es"
         else:
             if singular[-1] == "s":


### PR DESCRIPTION
Objects of kind 'Ingress' in Kubernetes were being rejected because of improper pluralization, and changing the pluralization rules is one manner to address that.

https://www.grammarly.com/handbook/mechanics/spelling/5/spelling-plurals-with-s-es-or-other-plurals/