### PR TITLE
use check_call instead of check_command

### DIFF
--- a/atomicapp/nulecule/container.py
+++ b/atomicapp/nulecule/container.py
@@ -85,7 +85,7 @@ class DockerHandler(object):
 
         if self.dryrun:
             logger.info("DRY-RUN: %s", pull_cmd)
-        elif subprocess.check_output(pull_cmd) != 0:
+        elif subprocess.check_call(pull_cmd) != 0:
             raise DockerException("Could not pull docker image: %s" % image)
 
         cockpit_logger.info('Skipping pulling docker image: %s' % image)


### PR DESCRIPTION
To check whether the return code is 0, the check_call method should be used instead of check_command.