### PR TITLE
False positive on pull

### DIFF
--- a/atomicapp/nulecule/container.py
+++ b/atomicapp/nulecule/container.py
@@ -85,8 +85,12 @@ class DockerHandler(object):
 
         if self.dryrun:
             logger.info("DRY-RUN: %s", pull_cmd)
-        elif subprocess.check_output(pull_cmd) != 0:
-            raise DockerException("Could not pull docker image: %s" % image)
+            return
+
+        try:
+            subprocess.check_output(pull_cmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            raise DockerException("Could not pull docker image: %s.\n%s" % (image, e.output))
 
         cockpit_logger.info('Skipping pulling docker image: %s' % image)
 


### PR DESCRIPTION
If using pulling an already pulled image, subprocess.check_output errors
out with a non 0 error code.

By using subprocess.CalledProcessError that explicit checks to see if
the command errors out, the false positive is removed.

Fixes #752 

Closes #751 