### PR TITLE
Show help when no arguments given.

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -412,7 +412,8 @@ class CLI():
 
     def run(self):
         cmdline = sys.argv[1:]  # Grab args from cmdline
-
+        if len(cmdline) == 0:
+            cmdline = ['-h']    # Show help if no arguments are given
         # Initial setup of logging (to allow for a few early debug statements)
         Logging.setup_logging(verbose=True, quiet=False)
 


### PR DESCRIPTION
Issue #668. 
`atomicapp` before it was failing to show the help when no arguments passed, now it shows help without any arguments.