### PR TITLE
Fixes connecting issues with OpenShift

### DIFF
--- a/atomicapp/providers/openshift.py
+++ b/atomicapp/providers/openshift.py
@@ -78,7 +78,8 @@ class OpenshiftClient(object):
             (status_code, return_data) = \
                 Utils.make_rest_request("get",
                                         self.openshift_api,
-                                        verify=self._requests_tls_verify())
+                                        verify=self._requests_tls_verify(),
+                                        headers={'Authorization': "Bearer %s" % self.access_token})
         except SSLError as e:
             if self.provider_tls_verify:
                 msg = "SSL/TLS ERROR: invalid certificate. " \
@@ -98,7 +99,8 @@ class OpenshiftClient(object):
         (status_code, return_data) = \
             Utils.make_rest_request("get",
                                     self.openshift_api,
-                                    verify=self._requests_tls_verify())
+                                    verify=self._requests_tls_verify(),
+                                    headers={'Authorization': "Bearer %s" % self.access_token})
         if status_code == 200:
             oapi_resources = return_data["resources"]
         else:
@@ -119,7 +121,8 @@ class OpenshiftClient(object):
         (status_code, return_data) = \
             Utils.make_rest_request("get",
                                     self.kubernetes_api,
-                                    verify=self._requests_tls_verify())
+                                    verify=self._requests_tls_verify(),
+                                    headers={'Authorization': "Bearer %s" % self.access_token})
         if status_code == 200:
             kapi_resources = return_data["resources"]
         else:
@@ -137,7 +140,8 @@ class OpenshiftClient(object):
             Utils.make_rest_request("post",
                                     url,
                                     verify=self._requests_tls_verify(),
-                                    data=artifact)
+                                    data=artifact,
+                                    headers={'Authorization': "Bearer %s" % self.access_token})
         if status_code == 201:
             logger.info("Object %s successfully deployed.",
                         artifact['metadata']['name'])
@@ -160,7 +164,8 @@ class OpenshiftClient(object):
         (status_code, return_data) = \
             Utils.make_rest_request("delete",
                                     url,
-                                    verify=self._requests_tls_verify())
+                                    verify=self._requests_tls_verify(),
+                                    headers={'Authorization': "Bearer %s" % self.access_token})
         if status_code == 200:
             logger.info("Successfully deleted.")
         else:
@@ -184,7 +189,8 @@ class OpenshiftClient(object):
             Utils.make_rest_request("patch",
                                     url,
                                     data=patch,
-                                    verify=self._requests_tls_verify())
+                                    verify=self._requests_tls_verify(),
+                                    headers={'Authorization': "Bearer %s" % self.access_token})
         if status_code == 200:
             logger.info("Successfully scaled to %s replicas", replicas)
         else:
@@ -197,7 +203,8 @@ class OpenshiftClient(object):
             Utils.make_rest_request("post",
                                     url,
                                     verify=self._requests_tls_verify(),
-                                    data=template)
+                                    data=template,
+                                    headers={'Authorization': "Bearer %s" % self.access_token})
         if status_code == 201:
             logger.info("template processed %s", template['metadata']['name'])
             logger.debug("processed template %s", return_data)
@@ -304,7 +311,10 @@ class OpenshiftClient(object):
             'namespaces/{namespace}/pods/{pod}?'
             'access_token={access_token}'.format(**args))
         (status_code, return_data) = \
-            Utils.make_rest_request("get", url, verify=self._requests_tls_verify())
+            Utils.make_rest_request("get",
+                                    url,
+                                    verify=self._requests_tls_verify(),
+                                    headers={'Authorization': "Bearer %s" % self.access_token})
 
         if status_code != 200:
             raise ProviderFailedException(

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -429,7 +429,7 @@ class Utils(object):
         return home
 
     @staticmethod
-    def make_rest_request(method, url, verify=True, data=None):
+    def make_rest_request(method, url, verify=True, data=None, headers={}):
         """
         Make HTTP request to url
 
@@ -456,15 +456,15 @@ class Utils(object):
 
         try:
             if method.lower() == "get":
-                res = requests.get(url, verify=verify)
+                res = requests.get(url, verify=verify, headers=headers)
             elif method.lower() == "post":
-                res = requests.post(url, json=data, verify=verify)
+                res = requests.post(url, json=data, verify=verify, headers=headers)
             elif method.lower() == "put":
-                res = requests.put(url, json=data, verify=verify)
+                res = requests.put(url, json=data, verify=verify, headers=headers)
             elif method.lower() == "delete":
-                res = requests.delete(url, json=data, verify=verify)
+                res = requests.delete(url, json=data, verify=verify, headers=headers)
             elif method.lower() == "patch":
-                headers = {"Content-Type": "application/json-patch+json"}
+                headers.update({"Content-Type": "application/json-patch+json"})
                 res = requests.patch(url, json=data, verify=verify, headers=headers)
 
             status_code = res.status_code


### PR DESCRIPTION
Due to
https://github.com/openshift/origin/commit/b7b6c01bc7d7c7592cce263da07a727e3758bd4b
which prevents the usage of the token via URL within OpenShift, the
token MUST be passed via the headers 'Authorization' parameter on HTTP
requests.

This commit adds the bearer token in order to fix an issue connecting to
OpenShift Origin 1.3