### PR TITLE
Modifies asking for parameters to show app name

### DIFF
--- a/atomicapp/nulecule/lib.py
+++ b/atomicapp/nulecule/lib.py
@@ -69,7 +69,7 @@ class NuleculeBase(object):
             if value is None and (ask or (
                     not skip_asking and param.get(DEFAULTNAME_KEY) is None)):
                 cockpit_logger.info("%s is missing in answers.conf." % param[NAME_KEY])
-                value = Utils.askFor(param[NAME_KEY], param)
+                value = Utils.askFor(param[NAME_KEY], param, self.namespace)
             elif value is None:
                 value = param.get(DEFAULTNAME_KEY)
             if config.get(self.namespace) is None:

--- a/atomicapp/utils.py
+++ b/atomicapp/utils.py
@@ -267,9 +267,10 @@ class Utils(object):
         return ec, stdout, stderr
 
     @staticmethod
-    def askFor(what, info):
+    def askFor(what, info, app_name):
         repeat = True
         desc = info["description"]
+        logger.debug(info)
         constraints = None
         if "constraints" in info:
             constraints = info["constraints"]
@@ -277,12 +278,12 @@ class Utils(object):
             repeat = False
             if "default" in info:
                 value = raw_input(
-                    "ANSWER >> %s (%s, default: %s): " % (what, desc, info["default"]))
+                    "ANSWER => %s | %s (%s, default: %s): " % (app_name, what, desc, info["default"]))
                 if len(value) == 0:
                     value = info["default"]
             else:
                 try:
-                    value = raw_input("ANSWER >> %s (%s): " % (what, desc))
+                    value = raw_input("ANSWER => %s | %s (%s): " % (app_name, what, desc))
                 except EOFError:
                     raise
 


### PR DESCRIPTION
Changes the output of when asking for parameters from

ANSWER >> db_pass (Database Password): test

to

ANSWER => etherpad-app | db_pass (Database Password): test

Closes https://github.com/projectatomic/atomicapp/issues/773