### PR TITLE
collect only atomicapp tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 test:
 	pip install -qr requirements.txt
 	pip install -qr test-requirements.txt
-	$(PYTHON) -m pytest -vv --cov atomicapp
+	$(PYTHON) -m pytest tests/ -vv --cov atomicapp
 
 .PHONY: image
 image:


### PR DESCRIPTION
In case of external libraries, their tests are not run, but only the ones in tests directory are run.