### PR TITLE
Use travis CI to run tests from tests/units dir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 test:
 	pip install -qr requirements.txt
 	pip install -qr test-requirements.txt
-	$(PYTHON) -m pytest tests/ -vv --cov atomicapp
+	$(PYTHON) -m pytest tests/units/ -vv --cov atomicapp
 
 .PHONY: image
 image:


### PR DESCRIPTION
This is needed so that travis CI does not end up running functional tests from ``tests/`` dir.