### PR TITLE
Add checking if resource is OpenShift specific to properly create OpenShift artifacts

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -540,5 +540,6 @@ def main():
     cli = CLI()
     cli.run()
 
+
 if __name__ == '__main__':
     main()

--- a/atomicapp/providers/lib/kubeshift/openshift.py
+++ b/atomicapp/providers/lib/kubeshift/openshift.py
@@ -180,6 +180,8 @@ class KubeOpenshiftClient(object):
                 url = self.k8s_api
             else:
                 url = urljoin(self.k8s_apis, "%s/" % api_version)
+        elif resource in self.oc_api_resources:
+            url = self.oc_api
         else:
             raise KubeOpenshiftError("No kind by that name: %s" % kind)
 

--- a/tests/units/kubeshift/test_openshift.py
+++ b/tests/units/kubeshift/test_openshift.py
@@ -43,7 +43,7 @@ class FakeClient():
         pass
 
     def get_resources(self, *args):
-        return ['Pod', 'template']
+        return ['Pod', 'template', 'Route']
 
     def get_groups(self, *args):
         return {}
@@ -57,7 +57,7 @@ class FakeClient():
 
 
 @mock.patch("atomicapp.providers.lib.kubeshift.openshift.KubeBase")
-def test_create(mock_class):
+def test_k8s_create(mock_class):
     # Mock the API class
     mock_class.return_value = FakeClient()
     mock_class.get_resources.return_value = ['Pod']
@@ -69,9 +69,29 @@ def test_create(mock_class):
     a = KubeOpenshiftClient(config)
     a.create(k8s_object, "foobar")
 
+@mock.patch("atomicapp.providers.lib.kubeshift.openshift.KubeBase")
+def test_oc_create(mock_class):
+    mock_class.return_value = FakeClient()
+    mock_class.get_resources.return_value = ['Route']
+    mock_class.kind_to_resource_name.return_value = 'Route'
+
+    oc_object = {"apiVersion": "v1", "kind": "Route", "metadata": {"labels": {"name": "helloapache-route"}, "name": "helloapache-route"}, "spec": {
+        "host": "$endpoint", "to": [{"kind": "Service", "name": "helloapache-svc"}]}}
+    a = KubeOpenshiftClient(config)
+    a.create(oc_object, "foobar")
 
 @mock.patch("atomicapp.providers.lib.kubeshift.openshift.KubeBase")
-def test_delete(mock_class):
+def test_oc_delete(mock_class):
+    mock_class.return_value = FakeClient()
+    mock_class.kind_to_resource_name.return_value = 'Route'
+
+    oc_object = {"apiVersion": "v1", "kind": "Route", "metadata": {"labels": {"name": "helloapache-route"}, "name": "helloapache-route"}, "spec": {
+        "host": "$endpoint", "to": [{"kind": "Service", "name": "helloapache-svc"}]}}
+    a = KubeOpenshiftClient(config)
+    a.delete(oc_object, "foobar")
+
+@mock.patch("atomicapp.providers.lib.kubeshift.openshift.KubeBase")
+def test_k8s_delete(mock_class):
     # Mock the API class
     mock_class.return_value = FakeClient()
     mock_class.kind_to_resource_name.return_value = 'Pod'


### PR DESCRIPTION
It appears that this file was copy pasted from the Kubernetes Kubeshift file and wasn't tested. Currently deploying an atomicapp which has a route as an artifact will fail since a route isn't listed as a Kubernetes resource. I tested this deploying an Etherpad atomicapp (https://github.com/fusor/nulecule-library/tree/master/etherpad-atomicapp) on Openshift with an added route artifact with success.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/87361382444136/210898191031938)
